### PR TITLE
Update build.xml to support ld --as-needed

### DIFF
--- a/src/native/build.xml
+++ b/src/native/build.xml
@@ -1263,8 +1263,8 @@
                 <linkerarg value="-Wl,--no-undefined" />
                 <linkerarg value="-Wl,-z,relro" if="is.running.debian"/>
                 <linkerarg value="-L/usr/local/lib/" if="is.running.freebsd"/>
-                <linkerarg value="-lpulse" />
-                <linkerarg value="-ldl" if="is.running.linux"/>
+                <linkerarg value="-lpulse" location="end"/>
+                <linkerarg value="-ldl" location="end" if="is.running.linux"/>
 
                 <compilerarg value="-m32" if="cross_32" />
                 <compilerarg value="-m64" if="cross_64" />


### PR DESCRIPTION
Ubuntu uses the linker option "--as-needed" by default. This requires that libraries are added in the correct order to the linker command line (i.e. after the objects requesting external symbols). This change fixes the build on Ubuntu.