### PR TITLE
Correctly load jitsi-defaults.properties when running under WebStart

### DIFF
--- a/src/org/jitsi/impl/configuration/ConfigurationServiceImpl.java
+++ b/src/org/jitsi/impl/configuration/ConfigurationServiceImpl.java
@@ -1683,7 +1683,8 @@ public class ConfigurationServiceImpl
 
             if(fileStream == null)
             {
-                logger.info("failed to find " + fileName + " with class loader, will continue without it.");
+                logger.info("failed to find " + fileName + " with class "
+                    + "loader, will continue without it.");
                 return;
             }
 


### PR DESCRIPTION
When running under WebStart, using ClassLoader.getSystemResourceAsStream(fileName) does not work at all.
