### PR TITLE
correct a command in README.md

### DIFF
--- a/src/native/vpx/README.md
+++ b/src/native/vpx/README.md
@@ -20,7 +20,7 @@ export JAVA_HOME=/usr/lib/jvm/default-java/
 
 ### Build the libjitsi code with the libvpx-debian ant target
 ```
-ant libvpx -Dlibmkv=/path/to/libvpx/third_party/libmkv
+ant libvpx-debian -Dlibmkv=/path/to/libvpx/third_party/libmkv
 ```
 
 


### PR DESCRIPTION
the typo is easy for people (like me) to copy and make mistakes, since there exists another target named 'libvpx'.