### PR TITLE
Modified audio channel retrieval

### DIFF
--- a/src/org/jitsi/impl/neomedia/device/MediaDeviceSession.java
+++ b/src/org/jitsi/impl/neomedia/device/MediaDeviceSession.java
@@ -1585,7 +1585,7 @@ public class MediaDeviceSession
         if (format instanceof AudioFormat)
         {
             AudioFormat audioFormat = (AudioFormat) format;
-            int channels = Format.NOT_SPECIFIED;
+            int channels = audioFormat.getChannels();
             double sampleRate
                 = OSUtils.IS_ANDROID
                     ? audioFormat.getSampleRate()


### PR DESCRIPTION
Forcing channels to Format.NOT_SPECIFIED negates the check in the "if" block on line 1594. Getting the specified channels from the AudioFormat would seem to be more effective.