### PR TITLE
Input buffer timestamp used instead of setting as unknown

### DIFF
--- a/src/org/jitsi/impl/neomedia/codec/video/h264/JNIDecoder.java
+++ b/src/org/jitsi/impl/neomedia/codec/video/h264/JNIDecoder.java
@@ -431,7 +431,7 @@ public class JNIDecoder
 
         if (pts == FFmpeg.AV_NOPTS_VALUE)
         {
-            out.setTimeStamp(Buffer.TIME_UNKNOWN);
+            out.setTimeStamp(in.getTimeStamp());
         }
         else
         {


### PR DESCRIPTION
Created as an addon for issue #28