### PR TITLE
Remove condition for S16LE sample format

### DIFF
--- a/src/org/jitsi/impl/neomedia/device/PulseAudioSystem.java
+++ b/src/org/jitsi/impl/neomedia/device/PulseAudioSystem.java
@@ -483,11 +483,6 @@ public class PulseAudioSystem
             List<CaptureDeviceInfo2> deviceList,
             List<Format> formatList)
     {
-        int sampleSpecFormat = PA.sink_info_get_sample_spec_format(sinkInfo);
-
-        if (sampleSpecFormat != PA.SAMPLE_S16LE)
-            return;
-
         String description = PA.sink_info_get_description(sinkInfo);
         String name = PA.sink_info_get_name(sinkInfo);
 
@@ -515,12 +510,6 @@ public class PulseAudioSystem
         int monitorOfSink = PA.source_info_get_monitor_of_sink(sourceInfo);
 
         if (monitorOfSink != PA.INVALID_INDEX)
-            return;
-
-        int sampleSpecFormat
-            = PA.source_info_get_sample_spec_format(sourceInfo);
-
-        if (sampleSpecFormat != PA.SAMPLE_S16LE)
             return;
 
         int channels = PA.source_info_get_sample_spec_channels(sourceInfo);


### PR DESCRIPTION
This prevents any device registered as a different format from
showing up in the device list.

This can be reproduced by overriding the pulseaudio default for sample rate in /etc/pulse/daemon.conf

default-sample-format = s32le

This condition prevented one of two sound cards from appearing in the device list only for pulseaudio. PortAudio worked Ok when selecting the "default" devices and configuring pulseaudio appropriately. It was clear that the sound card was fully functional. After removing this condition, the sound card now appears (and functions) as expected in both capture and playback device lists.

Without commentary in the code, it's unclear to me as to why this condition is present at all.