### PR TITLE
Adds a DebugTransformEngine.

### DIFF
--- a/src/org/jitsi/impl/neomedia/MediaStreamImpl.java
+++ b/src/org/jitsi/impl/neomedia/MediaStreamImpl.java
@@ -300,8 +300,7 @@ public class MediaStreamImpl
      * The <tt>TransformEngine</tt> instance that logs packets going in and out
      * of this <tt>MediaStream</tt>.
      */
-    private final DebugTransformEngine debugTransformEngine
-        = new DebugTransformEngine(this);
+    private DebugTransformEngine debugTransformEngine;
 
     /**
      * The <tt>TransformEngine</tt> instance registered in the
@@ -940,7 +939,12 @@ public class MediaStreamImpl
         engineChain.add(statisticsEngine);
 
         // Debug
-        engineChain.add(debugTransformEngine);
+        debugTransformEngine
+            = DebugTransformEngine.createDebugTransformEngine(this);
+        if (debugTransformEngine != null)
+        {
+            engineChain.add(debugTransformEngine);
+        }
 
         // SRTP
         engineChain.add(srtpControl.getTransformEngine());
@@ -3464,13 +3468,16 @@ public class MediaStreamImpl
         if (pkt == null)
             return;
 
-        PacketTransformer debugTransformer = data
-            ? debugTransformEngine.getRTPTransformer()
-            : debugTransformEngine.getRTCPTransformer();
+        if (debugTransformEngine != null)
+        {
+            PacketTransformer debugTransformer = data
+                ? debugTransformEngine.getRTPTransformer()
+                : debugTransformEngine.getRTCPTransformer();
 
-        // XXX we hard cast so that we don't have to create a new RawPacket
-        // array.
-        ((SinglePacketTransformer)debugTransformer).transform(pkt);
+            // XXX we hard cast so that we don't have to create a new RawPacket
+            // array.
+            ((SinglePacketTransformer)debugTransformer).transform(pkt);
+        }
 
         if (encrypt)
         {

--- a/src/org/jitsi/impl/neomedia/MediaStreamImpl.java
+++ b/src/org/jitsi/impl/neomedia/MediaStreamImpl.java
@@ -297,6 +297,13 @@ public class MediaStreamImpl
     private StatisticsEngine statisticsEngine = null;
 
     /**
+     * The <tt>TransformEngine</tt> instance that logs packets going in and out
+     * of this <tt>MediaStream</tt>.
+     */
+    private final DebugTransformEngine debugTransformEngine
+        = new DebugTransformEngine(this);
+
+    /**
      * The <tt>TransformEngine</tt> instance registered in the
      * <tt>RTPConnector</tt>'s transformer chain, which allows the "external"
      * transformer to be swapped.
@@ -921,9 +928,6 @@ public class MediaStreamImpl
         if (redTransformEngine != null)
             engineChain.add(redTransformEngine);
 
-        // Debug
-        // engineChain.add(new DebugTransformEngine(this));
-
         // RTCPTerminationTransformEngine passes received RTCP to
         // RTCPTerminationStrategy for inspection and modification. The RTCP
         // termination needs to be as close to the SRTP transform engine as
@@ -934,6 +938,9 @@ public class MediaStreamImpl
         if (statisticsEngine == null)
             statisticsEngine = new StatisticsEngine(this);
         engineChain.add(statisticsEngine);
+
+        // Debug
+        engineChain.add(debugTransformEngine);
 
         // SRTP
         engineChain.add(srtpControl.getTransformEngine());
@@ -3456,6 +3463,14 @@ public class MediaStreamImpl
     {
         if (pkt == null)
             return;
+
+        PacketTransformer debugTransformer = data
+            ? debugTransformEngine.getRTPTransformer()
+            : debugTransformEngine.getRTCPTransformer();
+
+        // XXX we hard cast so that we don't have to create a new RawPacket
+        // array.
+        ((SinglePacketTransformer)debugTransformer).transform(pkt);
 
         if (encrypt)
         {

--- a/src/org/jitsi/impl/neomedia/transform/DebugTransformEngine.java
+++ b/src/org/jitsi/impl/neomedia/transform/DebugTransformEngine.java
@@ -27,7 +27,7 @@ import java.net.*;
  *
  * <pre>
  * net.java.sip.communicator.packetlogging.PACKET_LOGGING_ENABLED=true
- * net.java.sip.communicator.packetlogging.PACKET_LOGGING_ENABLED=true
+ * net.java.sip.communicator.packetlogging.PACKET_LOGGING_ARBITRARY_ENABLED=true
  * net.java.sip.communicator.packetlogging.PACKET_LOGGING_FILE_COUNT=1
  * net.java.sip.communicator.packetlogging.PACKET_LOGGING_FILE_SIZE=-1
  * </pre>

--- a/src/org/jitsi/impl/neomedia/transform/DebugTransformEngine.java
+++ b/src/org/jitsi/impl/neomedia/transform/DebugTransformEngine.java
@@ -1,0 +1,305 @@
+/*
+ * Copyright @ 2015 Atlassian Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.impl.neomedia.transform;
+
+import org.jitsi.impl.libjitsi.*;
+import org.jitsi.impl.neomedia.*;
+import org.jitsi.service.packetlogging.*;
+
+import java.net.*;
+
+/**
+ * Logs all the packets that go in and out of a <tt>MediaStream</tt>.
+ *
+ * @author George Politis
+ */
+public class DebugTransformEngine implements TransformEngine
+{
+    //region State
+
+    /**
+     * The <tt>MediaStream</tt> that owns this instance.
+     */
+    private final MediaStreamImpl mediaStream;
+
+    /**
+     * The <tt>PacketTransformer</tt> that logs RTP packets.
+     */
+    private final PacketTransformer rtpTransformer
+        = new MyRTPPacketTransformer();
+
+    /**
+     * The <tt>PacketTransformer</tt> that logs RTCP packets.
+     */
+    private final PacketTransformer rtcpTransformer
+        = new MyRTCPPacketTransformer();
+
+    /**
+     * A boolean that indicates whether packet logging should be enabled or not.
+     */
+    private boolean enabled = false;
+
+    /**
+     * A boolean that indicates whether this instance has been initialized or
+     * not.
+     */
+    private boolean initialized = false;
+
+    //endregion
+
+    //region Public methods
+
+    /**
+     * Ctor.
+     *
+     * @param mediaStream the <tt>MediaStream</tt> that owns this instance.
+     */
+    public DebugTransformEngine(MediaStreamImpl mediaStream)
+    {
+        this.mediaStream = mediaStream;
+    }
+
+    @Override
+    public PacketTransformer getRTPTransformer()
+    {
+        return this.rtpTransformer;
+    }
+
+    @Override
+    public PacketTransformer getRTCPTransformer()
+    {
+        return this.rtcpTransformer;
+    }
+
+    //endregion
+
+    //region Private methods
+
+    private void assertInitialized()
+    {
+        if (initialized)
+        {
+            return;
+        }
+
+        initialized = true;
+
+        PacketLoggingService packetLogging
+            = LibJitsiImpl.getPacketLoggingService();
+
+        this.enabled = packetLogging != null
+            && packetLogging.isLoggingEnabled(
+                    PacketLoggingService.ProtocolName.ARBITRARY);
+    }
+
+    //endregion
+
+    //region Nested types
+
+    /**
+     * Logs RTP packets that go in and out of the <tt>MediaStream</tt> that owns
+     * this instance.
+     */
+    class MyRTPPacketTransformer
+        extends SinglePacketTransformer
+    {
+        @Override
+        public RawPacket reverseTransform(RawPacket pkt)
+        {
+            DebugTransformEngine.this.assertInitialized();
+            if (!enabled)
+            {
+                return pkt;
+            }
+
+            PacketLoggingService packetLogging
+                = LibJitsiImpl.getPacketLoggingService();
+
+            if (packetLogging != null)
+            {
+                InetSocketAddress sourceAddress
+                    = mediaStream.getTarget().getDataAddress();
+
+                InetSocketAddress destinationAddress
+                    = mediaStream.getLocalDataAddress();
+
+                packetLogging.logPacket(
+                    PacketLoggingService.ProtocolName.ARBITRARY,
+                    (sourceAddress != null)
+                        ? sourceAddress.getAddress().getAddress()
+                        : new byte[]{0, 0, 0, 0},
+                    (sourceAddress != null)
+                        ? sourceAddress.getPort()
+                        : 1,
+                    (destinationAddress != null)
+                        ? destinationAddress.getAddress().getAddress()
+                        : new byte[]{0, 0, 0, 0},
+                    (destinationAddress != null)
+                        ? destinationAddress.getPort()
+                        : 1,
+                    PacketLoggingService.TransportName.UDP,
+                    false,
+                    pkt.getBuffer().clone(),
+                    pkt.getOffset(),
+                    pkt.getLength());
+            }
+
+            return pkt;
+        }
+
+        @Override
+        public RawPacket transform(RawPacket pkt)
+        {
+            DebugTransformEngine.this.assertInitialized();
+            if (!enabled)
+            {
+                return pkt;
+            }
+
+            PacketLoggingService packetLogging
+                = LibJitsiImpl.getPacketLoggingService();
+
+            if (packetLogging != null)
+            {
+                InetSocketAddress sourceAddress
+                    = mediaStream.getLocalDataAddress();
+
+                InetSocketAddress destinationAddress
+                    = mediaStream.getTarget().getDataAddress();
+
+                packetLogging.logPacket(
+                    PacketLoggingService.ProtocolName.ARBITRARY,
+                    (sourceAddress != null)
+                        ? sourceAddress.getAddress().getAddress()
+                        : new byte[]{0, 0, 0, 0},
+                    (sourceAddress != null)
+                        ? sourceAddress.getPort()
+                        : 1,
+                    (destinationAddress != null)
+                        ? destinationAddress.getAddress().getAddress()
+                        : new byte[]{0, 0, 0, 0},
+                    (destinationAddress != null)
+                        ? destinationAddress.getPort()
+                        : 1,
+                    PacketLoggingService.TransportName.UDP,
+                    true,
+                    pkt.getBuffer().clone(),
+                    pkt.getOffset(),
+                    pkt.getLength());
+            }
+
+            return pkt;
+        }
+    }
+
+    /**
+     * Logs RTCP packets that go in and out of the <tt>MediaStream</tt> that
+     * owns this instance.
+     */
+    class MyRTCPPacketTransformer
+        extends SinglePacketTransformer
+    {
+        @Override
+        public RawPacket reverseTransform(RawPacket pkt)
+        {
+            DebugTransformEngine.this.assertInitialized();
+            if (!enabled)
+            {
+                return pkt;
+            }
+
+            PacketLoggingService packetLogging
+                = LibJitsiImpl.getPacketLoggingService();
+
+            if (packetLogging != null)
+            {
+                InetSocketAddress sourceAddress
+                    = mediaStream.getTarget().getControlAddress();
+
+                InetSocketAddress destinationAddress
+                    = mediaStream.getLocalControlAddress();
+
+                packetLogging.logPacket(
+                    PacketLoggingService.ProtocolName.ARBITRARY,
+                    (sourceAddress != null)
+                        ? sourceAddress.getAddress().getAddress()
+                        : new byte[]{0, 0, 0, 0},
+                    (sourceAddress != null)
+                        ? sourceAddress.getPort()
+                        : 1,
+                    (destinationAddress != null)
+                        ? destinationAddress.getAddress().getAddress()
+                        : new byte[]{0, 0, 0, 0},
+                    (destinationAddress != null)
+                        ? destinationAddress.getPort()
+                        : 1,
+                    PacketLoggingService.TransportName.UDP,
+                    false,
+                    pkt.getBuffer().clone(),
+                    pkt.getOffset(),
+                    pkt.getLength());
+            }
+
+            return pkt;
+        }
+
+        @Override
+        public RawPacket transform(RawPacket pkt)
+        {
+            DebugTransformEngine.this.assertInitialized();
+            if (!enabled)
+            {
+                return pkt;
+            }
+
+            PacketLoggingService packetLogging
+                = LibJitsiImpl.getPacketLoggingService();
+
+            if (packetLogging != null)
+            {
+                InetSocketAddress sourceAddress
+                    = mediaStream.getLocalControlAddress();
+
+                InetSocketAddress destinationAddress
+                    = mediaStream.getTarget().getControlAddress();
+
+                packetLogging.logPacket(
+                    PacketLoggingService.ProtocolName.ARBITRARY,
+                    (sourceAddress != null)
+                        ? sourceAddress.getAddress().getAddress()
+                        : new byte[]{0, 0, 0, 0},
+                    (sourceAddress != null)
+                        ? sourceAddress.getPort()
+                        : 1,
+                    (destinationAddress != null)
+                        ? destinationAddress.getAddress().getAddress()
+                        : new byte[]{0, 0, 0, 0},
+                    (destinationAddress != null)
+                        ? destinationAddress.getPort()
+                        : 1,
+                    PacketLoggingService.TransportName.UDP,
+                    true,
+                    pkt.getBuffer().clone(),
+                    pkt.getOffset(),
+                    pkt.getLength());
+            }
+
+            return pkt;
+        }
+    }
+
+    //endregion
+}

--- a/src/org/jitsi/impl/neomedia/transform/DebugTransformEngine.java
+++ b/src/org/jitsi/impl/neomedia/transform/DebugTransformEngine.java
@@ -42,7 +42,7 @@ import java.net.*;
  * Bash):
  *
  * <pre>
- * wireshark -k -i <(cat ~/.sip-communicator/log/jitsi0.pcap)
+ * wireshark -k -i &lt;(cat ~/.sip-communicator/log/jitsi0.pcap)
  * </pre>
  *
  * @author George Politis

--- a/src/org/jitsi/impl/neomedia/transform/DebugTransformEngine.java
+++ b/src/org/jitsi/impl/neomedia/transform/DebugTransformEngine.java
@@ -49,8 +49,6 @@ import java.net.*;
  */
 public class DebugTransformEngine implements TransformEngine
 {
-    //region State
-
     /**
      * The <tt>MediaStream</tt> that owns this instance.
      */
@@ -67,10 +65,6 @@ public class DebugTransformEngine implements TransformEngine
      */
     private final PacketTransformer rtcpTransformer
         = new MyRTCPPacketTransformer();
-
-    //endregion
-
-    //region Public methods
 
     /**
      * Ctor.
@@ -120,10 +114,6 @@ public class DebugTransformEngine implements TransformEngine
     {
         return this.rtcpTransformer;
     }
-
-    //endregion
-
-    //region Nested types
 
     /**
      * Logs RTP packets that go in and out of the <tt>MediaStream</tt> that owns
@@ -292,6 +282,4 @@ public class DebugTransformEngine implements TransformEngine
             return pkt;
         }
     }
-
-    //endregion
 }

--- a/src/org/jitsi/impl/neomedia/transform/DebugTransformEngine.java
+++ b/src/org/jitsi/impl/neomedia/transform/DebugTransformEngine.java
@@ -22,7 +22,28 @@ import org.jitsi.service.packetlogging.*;
 import java.net.*;
 
 /**
- * Logs all the packets that go in and out of a <tt>MediaStream</tt>.
+ * Logs all the packets that go in and out of a <tt>MediaStream</tt>. In order
+ * to use it, you can setup logging like this:
+ *
+ * <pre>
+ * net.java.sip.communicator.packetlogging.PACKET_LOGGING_ENABLED=true
+ * net.java.sip.communicator.packetlogging.PACKET_LOGGING_ENABLED=true
+ * net.java.sip.communicator.packetlogging.PACKET_LOGGING_FILE_COUNT=1
+ * net.java.sip.communicator.packetlogging.PACKET_LOGGING_FILE_SIZE=-1
+ * </pre>
+ *
+ * Next, you setup a named pipe like this:
+ *
+ * <pre>
+ * mkfifo ~/.sip-communicator/log/jitsi0.pcap
+ * </pre>
+ *
+ * Finally, you can launch Wireshark like this (assuming that you're using
+ * Bash):
+ *
+ * <pre>
+ * wireshark -k -i <(cat ~/.sip-communicator/log/jitsi0.pcap)
+ * </pre>
  *
  * @author George Politis
  */
@@ -47,17 +68,6 @@ public class DebugTransformEngine implements TransformEngine
     private final PacketTransformer rtcpTransformer
         = new MyRTCPPacketTransformer();
 
-    /**
-     * A boolean that indicates whether packet logging should be enabled or not.
-     */
-    private boolean enabled = false;
-
-    /**
-     * A boolean that indicates whether this instance has been initialized or
-     * not.
-     */
-    private boolean initialized = false;
-
     //endregion
 
     //region Public methods
@@ -70,6 +80,33 @@ public class DebugTransformEngine implements TransformEngine
     public DebugTransformEngine(MediaStreamImpl mediaStream)
     {
         this.mediaStream = mediaStream;
+    }
+
+    /**
+     * Creates and returns a new <tt>DebugTransformEngine</tt> if logging is
+     * enabled for <tt>PacketLoggingService.ProtocolName.ARBITRARY</tt>.
+     *
+     * @param mediaStream the <tt>MediaStream</tt> that will own the newly
+     * created <tt>DebugTransformEngine</tt>.
+     * @return a new <tt>DebugTransformEngine</tt> if logging is enabled for
+     * <tt>PacketLoggingService.ProtocolName.ARBITRARY</tt>, otherwise null.
+     */
+    public static DebugTransformEngine createDebugTransformEngine(
+            MediaStreamImpl mediaStream)
+    {
+        PacketLoggingService packetLogging
+            = LibJitsiImpl.getPacketLoggingService();
+
+        if (packetLogging != null && packetLogging.isLoggingEnabled(
+                    PacketLoggingService.ProtocolName.ARBITRARY))
+        {
+            return new DebugTransformEngine(mediaStream);
+        }
+        else
+        {
+            return null;
+        }
+
     }
 
     @Override
@@ -86,27 +123,6 @@ public class DebugTransformEngine implements TransformEngine
 
     //endregion
 
-    //region Private methods
-
-    private void assertInitialized()
-    {
-        if (initialized)
-        {
-            return;
-        }
-
-        initialized = true;
-
-        PacketLoggingService packetLogging
-            = LibJitsiImpl.getPacketLoggingService();
-
-        this.enabled = packetLogging != null
-            && packetLogging.isLoggingEnabled(
-                    PacketLoggingService.ProtocolName.ARBITRARY);
-    }
-
-    //endregion
-
     //region Nested types
 
     /**
@@ -119,12 +135,6 @@ public class DebugTransformEngine implements TransformEngine
         @Override
         public RawPacket reverseTransform(RawPacket pkt)
         {
-            DebugTransformEngine.this.assertInitialized();
-            if (!enabled)
-            {
-                return pkt;
-            }
-
             PacketLoggingService packetLogging
                 = LibJitsiImpl.getPacketLoggingService();
 
@@ -163,12 +173,6 @@ public class DebugTransformEngine implements TransformEngine
         @Override
         public RawPacket transform(RawPacket pkt)
         {
-            DebugTransformEngine.this.assertInitialized();
-            if (!enabled)
-            {
-                return pkt;
-            }
-
             PacketLoggingService packetLogging
                 = LibJitsiImpl.getPacketLoggingService();
 
@@ -215,12 +219,6 @@ public class DebugTransformEngine implements TransformEngine
         @Override
         public RawPacket reverseTransform(RawPacket pkt)
         {
-            DebugTransformEngine.this.assertInitialized();
-            if (!enabled)
-            {
-                return pkt;
-            }
-
             PacketLoggingService packetLogging
                 = LibJitsiImpl.getPacketLoggingService();
 
@@ -259,12 +257,6 @@ public class DebugTransformEngine implements TransformEngine
         @Override
         public RawPacket transform(RawPacket pkt)
         {
-            DebugTransformEngine.this.assertInitialized();
-            if (!enabled)
-            {
-                return pkt;
-            }
-
             PacketLoggingService packetLogging
                 = LibJitsiImpl.getPacketLoggingService();
 

--- a/src/org/jitsi/service/packetlogging/PacketLoggingConfiguration.java
+++ b/src/org/jitsi/service/packetlogging/PacketLoggingConfiguration.java
@@ -57,6 +57,13 @@ public class PacketLoggingConfiguration
         = "net.java.sip.communicator.packetlogging.PACKET_LOGGING_ICE4J_ENABLED";
 
     /**
+     * Configuration property for enabling/disabling arbitrary packet logging.
+     */
+    public final static String PACKET_LOGGING_ARBITRARY_ENABLED_PROPERTY_NAME
+        = "net.java.sip.communicator.packetlogging." +
+            "PACKET_LOGGING_ARBITRARY_ENABLED";
+
+    /**
      * Configuration property for packet logging file count.
      */
     public final static String PACKET_LOGGING_FILE_COUNT_PROPERTY_NAME
@@ -92,6 +99,11 @@ public class PacketLoggingConfiguration
      * Is Packet Logging Service enabled for ice4j.
      */
     private boolean ice4jLoggingEnabled = true;
+
+    /**
+     * Is Packet Logging Service enabled for arbitrary packets.
+     */
+    private boolean arbitraryLoggingEnabled = true;
 
     /**
      * The limit for the file size.
@@ -146,11 +158,22 @@ public class PacketLoggingConfiguration
     /**
      * Checks whether packet logging is enabled in the configuration
      * for Ice4J.
-     * @return <tt>true</tt> if packet logging is enabled for RTP.
+     * @return <tt>true</tt> if packet logging is enabled for Ice4J.
      */
     public boolean isIce4JLoggingEnabled()
     {
         return this.ice4jLoggingEnabled;
+    }
+
+    /**
+     * Checks whether packet logging is enabled in the configuration
+     * for arbitrary packets.
+     * @return <tt>true</tt> if packet logging is enabled for arbitrary
+     * packets.
+     */
+    public boolean isArbitraryLoggingEnabled()
+    {
+        return this.arbitraryLoggingEnabled;
     }
 
     /**
@@ -184,6 +207,7 @@ public class PacketLoggingConfiguration
             this.jabberLoggingEnabled = false;
             this.rtpLoggingEnabled = false;
             this.ice4jLoggingEnabled = false;
+            this.arbitraryLoggingEnabled = false;
         }
 
         this.globalLoggingEnabled = enabled;
@@ -223,6 +247,15 @@ public class PacketLoggingConfiguration
     public void setIce4JLoggingEnabled(boolean enabled)
     {
         this.ice4jLoggingEnabled = true;
+    }
+
+    /**
+     * Change whether packet logging for arbitrary packets is enabled.
+     * @param enabled <tt>true</tt> if we enable it.
+     */
+    public void setArbitraryLoggingEnabled(boolean enabled)
+    {
+        this.arbitraryLoggingEnabled = true;
     }
 
     /**

--- a/src/org/jitsi/service/packetlogging/PacketLoggingService.java
+++ b/src/org/jitsi/service/packetlogging/PacketLoggingService.java
@@ -53,7 +53,12 @@ public interface PacketLoggingService
         /**
          * DNS protocol name.
          */
-        DNS
+        DNS,
+
+        /**
+         * ARBITRARY protocol name.
+         */
+        ARBITRARY
     }
 
     /**


### PR DESCRIPTION
I had this lying around for a while and I thought that it might be helpful for somebody else. It requires some change in the PacketLoggingServiceImplementation as well so that it actually logs ARBITRARY packets.

You can setup logging like this:
```
net.java.sip.communicator.packetlogging.PACKET_LOGGING_ENABLED=true
net.java.sip.communicator.packetlogging.PACKET_LOGGING_ARBITRARY_ENABLED=true
net.java.sip.communicator.packetlogging.PACKET_LOGGING_FILE_COUNT=1
net.java.sip.communicator.packetlogging.PACKET_LOGGING_FILE_SIZE=-1
```

You setup a named pipe like this:
```
mkfifo ~/.sip-communicator/log/jitsi0.pcap
```

You launch Wireshark like this:
```
wireshark -k -i <(cat ~/.sip-communicator/log/jitsi0.pcap)
```