### PR TITLE
Use fixed Random seed values and a latch for test consistency.

### DIFF
--- a/test/org/jitsi/sctp4j/SctpTransferTest.java
+++ b/test/org/jitsi/sctp4j/SctpTransferTest.java
@@ -16,9 +16,11 @@
 package org.jitsi.sctp4j;
 
 import org.junit.*;
+import static org.junit.Assert.*;
 
 import java.io.*;
 import java.util.*;
+import java.util.concurrent.*;
 
 import static org.junit.Assert.assertArrayEquals;
 
@@ -37,16 +39,15 @@ public class SctpTransferTest
 
     private final int portB = 5001;
 
-    private final Object transferLock = new Object();
-
-    /** @GuardedBy("transferLock") */
     private byte[] receivedData = null;
-
-    /** @GuardedBy("transferLock") */
-    private boolean dataReady = false;
 
     /** Set random generator seed for consistent tests. */
     private static final Random rand = new Random(12345);
+
+    private final int ITERATIONS = 10;
+
+    /** how long to wait for data during lossy send. */
+    private final long SECONDS_TO_WAIT = 10;
 
     @Before
     public void setUp()
@@ -94,11 +95,15 @@ public class SctpTransferTest
         peerB.connect(portA);
 
         byte[] toSendA = createRandomData(2*1024);
-        for(int i=0; i < 10; i++)
+        for(int i=0; i < ITERATIONS; i++)
         {
+            System.out.println("Broken Link Test " + (i+1) + " of " 
+                               + ITERATIONS + 
+                               ". NOTE: IOExceptions may be visible " +
+                               "during this test, and are expected.");
             try
             {
-                testTransferPart(peerA, peerB, toSendA);
+                testTransferPart(peerA, peerB, toSendA, SECONDS_TO_WAIT);
             }
             catch (Exception e)
             {
@@ -108,37 +113,43 @@ public class SctpTransferTest
     }
 
     private void testTransferPart(SctpSocket sender, SctpSocket receiver,
-                                  byte[] testData)
+                                  byte[] testData, long timeoutInSeconds)
         throws Exception
     {
+        final CountDownLatch dataReceivedLatch = new CountDownLatch(1);
+        boolean noTimeoutOccurred;
         receiver.setDataCallback(new SctpDataCallback()
         {
             @Override
             public void onSctpPacket(byte[] data, int sid, int ssn, int tsn,
                                      long ppid,
-                                     int context, int flags)
-            {
-                synchronized (transferLock)
-                {
-                    receivedData = data;
-                    dataReady = true;
-                    transferLock.notifyAll();
-                }
+                                     int context, int flags) {
+                receivedData = data;
+                dataReceivedLatch.countDown();
             }
         });
 
         sender.send(testData, true, 0, 0);
-
-        synchronized (transferLock)
+	try 
         {
-            while (!dataReady)
-                transferLock.wait();
-            assertArrayEquals(testData, receivedData);
-	    dataReady = false;
+            noTimeoutOccurred = dataReceivedLatch.await(timeoutInSeconds, 
+                                                        TimeUnit.SECONDS);
+            if (noTimeoutOccurred) {
+                assertArrayEquals(testData, receivedData);
+            } else {
+                fail("Test data did not get received within " +
+                     timeoutInSeconds + " seconds.");
+            }
+        } 
+        catch (InterruptedException ie) 
+        {
+            fail("Test was interrupted: " + ie.toString());
+            throw ie;
         }
     }
 
-    private static Random getRandom() {
+    private static Random getRandom() 
+    {
         return rand;
     }
 }

--- a/test/org/jitsi/sctp4j/TestLink.java
+++ b/test/org/jitsi/sctp4j/TestLink.java
@@ -16,6 +16,7 @@
 package org.jitsi.sctp4j;
 
 import java.io.*;
+import java.util.*;
 
 /**
  * The link that loses some packets and produces IOExceptions from time to time.
@@ -28,6 +29,9 @@ public class TestLink
     private final double lossRate;
 
     private final double errorRate;
+
+    /** Set random seed for consistent tests */
+    private static final Random rand = new Random(1234567);
 
     public TestLink(SctpSocket a, SctpSocket b,
                     double lossRate, double errorRate)
@@ -43,7 +47,7 @@ public class TestLink
     public void onConnOut(SctpSocket s, byte[] packet)
         throws IOException
     {
-        double r = Math.random();
+        double r = getRandomDouble();
 
         if(r < (errorRate + lossRate))
         {
@@ -59,5 +63,9 @@ public class TestLink
         }
         // Eventually pass the data
         super.onConnOut(s, packet);
+    }
+
+    private static double getRandomDouble() {
+        return rand.nextDouble();
     }
 }


### PR DESCRIPTION
Use independent Random instances with fixed seed values for consistency.
Also use the wait form described in JCIP 14.2.2.

Tried a couple of seed values that would still exercise the tests but complete in under a minute on my machine. The modification to the synchronizer, e.g. using wait in a loop with condition predicate being checked as described by Goetz et al in JCIP 14.2.2, might have fixed a bug.

Test consistently passes and in a reasonable amount of time.