### PR TITLE
Add .gitattributes to prevent future EOL problems

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.java text eol=lf diff=java


### PR DESCRIPTION
my script was only converting mixed EOL (CRLF and LF),
6 files remains with CRLF only, please run
find -name '*.java' | xargs file | grep 'CRLF' | cut -d ':' -f1 | xargs -n1 dos2unix
