### PR TITLE
Logs a message whenever a packet arrives less than 10ms after its

### DIFF
--- a/src/org/jitsi/impl/neomedia/transform/RetransmissionRequester.java
+++ b/src/org/jitsi/impl/neomedia/transform/RetransmissionRequester.java
@@ -353,7 +353,18 @@ public class RetransmissionRequester
                 // An older packet, possibly already requested.
                 // We don't update nextRequestAt here. The reading thread might
                 // wake up unnecessarily and do some extra work, but that's OK.
-                requests.remove(seq);
+                Request r = requests.remove(seq);
+                if (r != null && logger.isDebugEnabled())
+                {
+                    long delta
+                        = System.currentTimeMillis() - r.firstRequestSentAt;
+                    if (delta < 10)
+                    {
+                        logger.debug(hashCode()
+                                     + " received a missing packet only "
+                                     + delta + "ms after it was requested.");
+                    }
+                }
             }
             else if (diff == 1)
             {


### PR DESCRIPTION
retransmission was requested with a NACK. Such cases would indicate (unless the RTT
is <10ms) that the NACK was not necessary.