### PR TITLE
Use fixed Random seed values and a latch for test consistency.

### DIFF
--- a/test/org/jitsi/sctp4j/SctpTransferTest.java
+++ b/test/org/jitsi/sctp4j/SctpTransferTest.java
@@ -16,9 +16,11 @@
 package org.jitsi.sctp4j;
 
 import org.junit.*;
+import static org.junit.Assert.*;
 
 import java.io.*;
 import java.util.*;
+import java.util.concurrent.*;
 
 import static org.junit.Assert.assertArrayEquals;
 
@@ -37,9 +39,32 @@ public class SctpTransferTest
 
     private final int portB = 5001;
 
-    private final Object transferLock = new Object();
-
     private byte[] receivedData = null;
+
+    /**
+     * Set random generator seed for consistent tests.
+     */
+    private static final Random rand = new Random(12345);
+
+    /**
+     * How many tests to perform.
+     */
+    private final int ITERATIONS = 10;
+
+    /**
+     * How long to wait for data during lossy send.
+     */
+    private final long SECONDS_TO_WAIT = 10;
+
+    /**
+     * The loss rate to simulate.
+     */
+    private final double LOSS_RATE = 0.2;
+
+    /**
+     * The error rate to simulate.
+     */
+    private final double ERROR_RATE = 0.1;
 
     @Before
     public void setUp()
@@ -63,7 +88,7 @@ public class SctpTransferTest
     public static byte[] createRandomData(int size)
     {
         byte[] dummy = new byte[size];
-        new Random().nextBytes(dummy);
+        rand.nextBytes(dummy);
         return dummy;
     }
 
@@ -76,9 +101,7 @@ public class SctpTransferTest
     public void testSocketBrokenLink()
         throws Exception
     {
-        TestLink link = new TestLink(peerA, peerB,
-                                     0.2, /* loss rate */
-                                     0.1  /* error rate */);
+        TestLink link = new TestLink(peerA, peerB, LOSS_RATE, ERROR_RATE);
 
         peerA.setLink(link);
         peerB.setLink(link);
@@ -87,11 +110,14 @@ public class SctpTransferTest
         peerB.connect(portA);
 
         byte[] toSendA = createRandomData(2*1024);
-        for(int i=0; i < 10; i++)
+        for(int i=0; i < ITERATIONS; i++)
         {
+            System.out.println("Testing broken link, iteration " + (i+1)
+                    + " of " + ITERATIONS + ". NOTE: IOExceptions may be "
+                    + "visible during this test, and are expected.");
             try
             {
-                testTransferPart(peerA, peerB, toSendA, 5000);
+                testTransferPart(peerA, peerB, toSendA, SECONDS_TO_WAIT);
             }
             catch (Exception e)
             {
@@ -100,32 +126,52 @@ public class SctpTransferTest
         }
     }
 
-    private void testTransferPart(SctpSocket sender, SctpSocket receiver,
-                                  byte[] testData, long timeout)
+    private void testTransferPart(
+            SctpSocket sender,
+            SctpSocket receiver,
+            byte[] testData,
+            long timeoutInSeconds)
         throws Exception
     {
-        receiver.setDataCallback(new SctpDataCallback()
-        {
-            @Override
-            public void onSctpPacket(byte[] data, int sid, int ssn, int tsn,
-                                     long ppid,
-                                     int context, int flags)
+        final CountDownLatch dataReceivedLatch = new CountDownLatch(1);
+        boolean noTimeoutOccurred;
+        receiver.setDataCallback(
+            new SctpDataCallback()
             {
-                synchronized (transferLock)
+                @Override
+                public void onSctpPacket(
+                        byte[] data,
+                        int sid,
+                        int ssn,
+                        int tsn,
+                        long ppid,
+                        int context,
+                        int flags)
                 {
                     receivedData = data;
-                    transferLock.notifyAll();
+                    dataReceivedLatch.countDown();
                 }
-            }
-        });
+            });
 
         sender.send(testData, true, 0, 0);
-
-        synchronized (transferLock)
+        try
         {
-            transferLock.wait(timeout);
-
-            assertArrayEquals(testData, receivedData);
+            noTimeoutOccurred
+                = dataReceivedLatch.await(timeoutInSeconds, TimeUnit.SECONDS);
+            if (noTimeoutOccurred)
+            {
+                assertArrayEquals(testData, receivedData);
+            }
+            else
+            {
+                fail("Test data did not get received within "
+                        + timeoutInSeconds + " seconds.");
+            }
+        }
+        catch (InterruptedException ie)
+        {
+            fail("Test was interrupted: " + ie.toString());
+            throw ie;
         }
     }
 }

--- a/test/org/jitsi/sctp4j/TestLink.java
+++ b/test/org/jitsi/sctp4j/TestLink.java
@@ -16,9 +16,11 @@
 package org.jitsi.sctp4j;
 
 import java.io.*;
+import java.util.*;
 
 /**
- * The link that loses some packets and produces IOExceptions from time to time.
+ * The link that loses some packets and
+ * produces IOExceptions from time to time.
  *
  * @author Pawel Domas
  */
@@ -29,13 +31,19 @@ public class TestLink
 
     private final double errorRate;
 
-    public TestLink(SctpSocket a, SctpSocket b,
-                    double lossRate, double errorRate)
+    /**
+     * Set random seed for consistent tests
+     */
+    private static final Random rand = new Random(1234567);
+
+    public TestLink(
+            SctpSocket a,
+            SctpSocket b,
+            double lossRate,
+            double errorRate)
     {
         super(a, b);
-
         this.lossRate = lossRate;
-
         this.errorRate = errorRate;
     }
 
@@ -43,9 +51,9 @@ public class TestLink
     public void onConnOut(SctpSocket s, byte[] packet)
         throws IOException
     {
-        double r = Math.random();
+        double r = rand.nextDouble();
 
-        if(r < (errorRate + lossRate))
+        if (r < (errorRate + lossRate))
         {
             if (r < errorRate)
             {


### PR DESCRIPTION
Communicate that testing is happening and differentiate test outcomes.

Tried a couple of fixed seed values that would still exercise the
tests but complete in under a minute on my machine.

Test consistently passes and in a reasonable amount of time.

Formatting.

This PR is a replacement for https://github.com/jitsi/libjitsi/pull/77 (when force pushing updates to that branch, all the comments disappeared).