### PR TITLE
Generate RSA keypair / certificate only once in DtlsControlImpl

### DIFF
--- a/src/org/jitsi/impl/neomedia/transform/dtls/DtlsControlImpl.java
+++ b/src/org/jitsi/impl/neomedia/transform/dtls/DtlsControlImpl.java
@@ -248,28 +248,14 @@ public class DtlsControlImpl
                 /**
                  * {@inheritDoc}
                  *
-                 * Employs <tt>ZrtpFortuna</tt> as is common in neomedia. Most
-                 * importantly though, works around a possible hang on Linux
-                 * when reading from <tt>/dev/random</tt>.
+                 * force usage of non blocking pool (/dev/urandom)
                  */
                 @Override
                 public byte[] generateSeed(int numBytes)
                 {
                     byte[] seed = new byte[numBytes];
-
-                    ZrtpFortuna.getInstance().nextBytes(seed);
+                    this.nextBytes(seed);
                     return seed;
-                }
-
-                /**
-                 * {@inheritDoc}
-                 *
-                 * Employs <tt>ZrtpFortuna</tt> as is common in neomedia.
-                 */
-                @Override
-                public void nextBytes(byte[] bytes)
-                {
-                    ZrtpFortuna.getInstance().nextBytes(bytes);
                 }
             };
     }


### PR DESCRIPTION
security implications need to be reviewed carrefully!!
I don't see why we generate a new RSA keypair and certificate for each dtls conn when on a web server we change them every year or more. Is it ok to share the cert for all connections ?

Top 10 functions is now (this includes some unmerged patch):
(t  6,0,s  6,0) java.lang.Object.wait
(t  5,0,s  5,0) java.net.PlainDatagramSocketImpl.send
(t  3,1,s  3,0) java.net.PlainDatagramSocketImpl.receive0
(t  1,5,s  1,5) org.jitsi.impl.neomedia.transform.srtp.OpenSSLHMAC.HMAC_Update
(t  2,5,s  1,1) java.util.concurrent.locks.AbstractQueuedSynchronizer.release
(t  1,7,s  1,1) org.ice4j.socket.MultiplexingXXXSocketSupport.acceptBySocketsOrThis
(t  1,0,s  1,0) java.lang.Object.notifyAll
(t  1,0,s  1,0) java.util.concurrent.locks.ReentrantLock$Sync.tryRelease
(t  1,0,s  1,0) sun.misc.Unsafe.park
(t  1,0,s  1,0) org.jitsi.impl.neomedia.transform.srtp.SRTPCipherCTROpenSSL.AES128CTR_CTX_process

this was:
(t  6,6,s  6,6) java.math.BigInteger.montReduce
(t  5,0,s  3,7) java.math.BigInteger.squareToLen
(t  2,4,s  2,3) java.lang.Object.wait
(t  2,1,s  2,1) java.net.PlainDatagramSocketImpl.send
(t  1,4,s  1,4) java.net.PlainDatagramSocketImpl.receive0
(t  1,9,s  1,3) java.lang.ClassLoader.defineClass1
(t  1,3,s  1,3) java.math.BigInteger.addOne
(t  1,3,s  1,3) java.math.MutableBigInteger.divWord
(t  0,6,s  0,6) java.math.MutableBigInteger.divideOneWord
(t  0,6,s  0,6) org.jitsi.impl.neomedia.transform.srtp.OpenSSLHMAC.HMAC_Update