### PR TITLE
Closes #cachingTransformer on MediaStreamImpl#close(), fixing a leak

### DIFF
--- a/src/org/jitsi/impl/neomedia/MediaStreamImpl.java
+++ b/src/org/jitsi/impl/neomedia/MediaStreamImpl.java
@@ -334,8 +334,7 @@ public class MediaStreamImpl
      * The transformer which caches outgoing RTP packets for this
      * {@link MediaStream}.
      */
-    private final CachingTransformer cachingTransformer
-            = createCachingTransformer();
+    private CachingTransformer cachingTransformer = createCachingTransformer();
 
     /**
      * The chain used to by the RTPConnector to transform packets.
@@ -697,6 +696,12 @@ public class MediaStreamImpl
         if (csrcEngine != null)
         {
             csrcEngine = null;
+        }
+
+        if (cachingTransformer != null)
+        {
+            cachingTransformer.close();
+            cachingTransformer = null;
         }
 
         if (transformEngineChain != null)


### PR DESCRIPTION
when jitsi-videobridge performs health checks. We cannot rely on it
being closed with #transformEngineChain, because the chain isn't always
initialized (when helath-checks are run on jitsi-videobridge, it creates
MediaStreams but never sets their RTPConnector, so the chain is never
created.