### PR TITLE
Preliminary work to support FIR and PLI handling in the hammer.

### DIFF
--- a/src/org/jitsi/impl/neomedia/MediaStreamStatsImpl.java
+++ b/src/org/jitsi/impl/neomedia/MediaStreamStatsImpl.java
@@ -308,7 +308,7 @@ public class MediaStreamStatsImpl
     /**
      * The list of listeners to be notified when NACK packets are received.
      */
-    private final List<NACKListener> nackListeners = new LinkedList<>();
+    private final List<RTCPListener> RTCPListeners = new LinkedList<>();
 
     /**
      * The list of listeners to be notified when REMB packets are received.
@@ -1516,9 +1516,39 @@ public class MediaStreamStatsImpl
     {
         if (nack != null)
         {
-            for (NACKListener listener : nackListeners)
+            for (RTCPListener listener : RTCPListeners)
             {
                 listener.nackReceived(nack);
+            }
+        }
+    }
+
+    /**
+     * Notifies this instance that an RTCP FIR packet was received.
+     * @param fir the packet.
+     */
+    public void firReceived(FIRPacket fir)
+    {
+        if (fir != null)
+        {
+            for (RTCPListener listener : RTCPListeners)
+            {
+                listener.firReceived(fir);
+            }
+        }
+    }
+
+    /**
+     * Notifies this instance that an RTCP PLI packet was received.
+     * @param pli the packet.
+     */
+    public void pliReceived(PLIPacket pli)
+    {
+        if (pli != null)
+        {
+            for (RTCPListener listener : RTCPListeners)
+            {
+                listener.pliReceived(pli);
             }
         }
     }
@@ -1527,13 +1557,13 @@ public class MediaStreamStatsImpl
      * {@inheritDoc}
      */
     @Override
-    public void addNackListener(NACKListener listener)
+    public void addNackListener(RTCPListener listener)
     {
         if (listener != null)
         {
-            synchronized (nackListeners)
+            synchronized (RTCPListeners)
             {
-                nackListeners.add(listener);
+                RTCPListeners.add(listener);
             }
         }
     }

--- a/src/org/jitsi/impl/neomedia/rtcp/FIRPacket.java
+++ b/src/org/jitsi/impl/neomedia/rtcp/FIRPacket.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright @ 2015 Atlassian Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.impl.neomedia.rtcp;
+
+import net.sf.fmj.media.rtp.*;
+
+import java.io.*;
+
+/**
+ * The Feedback Control Information (FCI) for the Full Intra Request
+ * consists of one or more FCI entries, the content of which is depicted
+ * in the figure below.  The length of the FIR feedback message MUST be set to
+ * 2+2*N, where N is the number of FCI entries.
+ *
+ * 0                   1                   2                   3
+ * 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |                              SSRC                             |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * | Seq nr.       |    Reserved                                   |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *
+ * SSRC (32 bits): The SSRC value of the media sender that is
+ * requested to send a decoder refresh point.
+ *
+ * Seq nr. (8 bits): Command sequence number.  The sequence number
+ * space is unique for each pairing of the SSRC of command
+ * source and the SSRC of the command target.  The sequence
+ * number SHALL be increased by 1 modulo 256 for each new
+ * command.  A repetition SHALL NOT increase the sequence
+ * number.  The initial value is arbitrary.
+ *
+ * Reserved (24 bits): All bits SHALL be set to 0 by the sender and
+ * SHALL be ignored on reception.
+ *
+ * @author George Politis
+ */
+public class FIRPacket extends RTCPFBPacket
+{
+    /**
+     * The FIR message is identified by RTCP packet type value PT=PSFB and
+     * FMT=4.
+     */
+    public static final int FMT = 4;
+
+    /**
+     * The "SSRC of media source" is not used and SHALL be set to 0.
+     */
+    private static final int MEDIA_SOURCE_SSRC = 0;
+
+    /**
+     * The FCI entries in this FIR.
+     */
+    private FIRPacketEntry[] fciEntries;
+
+    /**
+     * Ctor to use when creating an FIR from scratch.
+     *
+     * @param fciEntries
+     * @param senderSSRC
+     */
+    public FIRPacket(FIRPacketEntry[] fciEntries, long senderSSRC)
+    {
+        super(FMT, PSFB, senderSSRC, MEDIA_SOURCE_SSRC);
+        this.fciEntries = fciEntries;
+    }
+
+    /**
+     * Ctor to use when reading an FIR.
+     *
+     * @param base
+     */
+    public FIRPacket(RTCPCompoundPacket base)
+    {
+        super(base);
+        super.fmt = FMT;
+        super.type = PSFB;
+    }
+
+    /**
+     * Parses the FCI field of a packet that appears to be an FIR.
+     *
+     * @param base
+     * @param firstbyte
+     * @param rtpfb
+     * @param length
+     * @param in
+     * @param senderSSRC
+     * @param sourceSSRC
+     * @return
+     */
+    public static RTCPPacket parse(
+        RTCPCompoundPacket base,
+        int firstbyte, int rtpfb, int length, DataInputStream in,
+        long senderSSRC, long sourceSSRC) throws IOException
+    {
+        // TODO(gp) implement lazy parsing.
+        // TODO(gp) standarize RTCPFBPacket parsing.
+
+        FIRPacket firPacket = new FIRPacket(base);
+
+        int numOfFciEntries = (length - 12) / 8;
+
+        firPacket.fciEntries = new FIRPacketEntry[numOfFciEntries];
+
+        for (int i = 0; i < numOfFciEntries; i++)
+        {
+            long ssrc = in.readInt() & 0xffffffffL;
+            int sequenceNumber = in.readUnsignedByte();
+            in.readByte();
+            in.readByte();
+            in.readByte();
+
+            firPacket.fciEntries[i] = new FIRPacketEntry(ssrc, sequenceNumber);
+        }
+
+        return firPacket;
+    }
+
+    @Override
+    public void assemble(DataOutputStream out)
+        throws IOException
+    {
+        out.writeByte((byte) (0x80 /* version */ | FMT));
+        out.writeByte((byte) PSFB);
+
+        int numOfFciEntries = fciEntries != null ? fciEntries.length : 0;
+        out.writeShort(2 + (2* numOfFciEntries));
+        writeSsrc(out, senderSSRC);
+        writeSsrc(out, sourceSSRC);
+
+        if (fciEntries != null || fciEntries.length != 0)
+        {
+            for (int i = 0; i < fciEntries.length; i++)
+            {
+                FIRPacketEntry entry = fciEntries[i];
+                writeSsrc(out, entry.ssrc);
+                out.writeByte(entry.sequenceNumber);
+                out.writeByte(0);
+                out.writeByte(0);
+                out.writeByte(0);
+            }
+        }
+
+    }
+
+    @Override
+    public int calcLength()
+    {
+        // Length (16 bits):  The length of this packet in 32-bit words minus
+        // one, including the header and any padding.
+
+        int len = 12; // header+ssrc+ssrc
+        if (fciEntries != null && fciEntries.length != 0)
+        {
+            len += 2 * fciEntries.length;
+        }
+
+        return len;
+    }
+
+    /**
+     * Structure that represents an FCI entry in the FIR packet.
+     */
+    public static class FIRPacketEntry
+    {
+        /**
+         * Ctor.
+         *
+         * @param ssrc
+         * @param sequenceNumber
+         */
+        public FIRPacketEntry(long ssrc, int sequenceNumber)
+        {
+            this.ssrc = ssrc;
+            this.sequenceNumber = sequenceNumber;
+        }
+
+        /**
+         * (32 bits): The SSRC value of the media sender that is requested to
+         * send a decoder refresh point.
+         */
+        private final long ssrc;
+
+        /**
+         * (8 bits): Command sequence number.  The sequence number
+         * space is unique for each pairing of the SSRC of command
+         * source and the SSRC of the command target.  The sequence
+         * number SHALL be increased by 1 modulo 256 for each new
+         * command.  A repetition SHALL NOT increase the sequence
+         * number.  The initial value is arbitrary.
+         */
+        private final int sequenceNumber;
+    }
+}

--- a/src/org/jitsi/impl/neomedia/rtcp/NACKPacket.java
+++ b/src/org/jitsi/impl/neomedia/rtcp/NACKPacket.java
@@ -163,15 +163,6 @@ public class NACKPacket
         return lostPackets;
     }
 
-    private void writeSsrc(DataOutputStream dataOutputStream, long ssrc)
-        throws IOException
-    {
-        dataOutputStream.writeByte((byte) (ssrc >> 24));
-        dataOutputStream.writeByte((byte) ((ssrc >> 16) & 0xFF));
-        dataOutputStream.writeByte((byte) ((ssrc >> 8) & 0xFF));
-        dataOutputStream.writeByte((byte) (ssrc & 0xFF));
-    }
-
     @Override
     public void assemble(DataOutputStream dataoutputstream)
         throws IOException

--- a/src/org/jitsi/impl/neomedia/rtcp/PLIPacket.java
+++ b/src/org/jitsi/impl/neomedia/rtcp/PLIPacket.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright @ 2015 Atlassian Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.impl.neomedia.rtcp;
+
+import net.sf.fmj.media.rtp.*;
+
+import java.io.*;
+
+/**
+ * @author George Politis
+ */
+public class PLIPacket extends RTCPFBPacket
+{
+    /**
+     * The PLI FB message is identified by PT=PSFB and FMT=1.
+     */
+    public static final int FMT = 1;
+
+    /**
+     * Ctor to use when creating a PLI from scratch.
+     *
+     * @param senderSSRC
+     * @param sourceSSRC
+     */
+    public PLIPacket(long senderSSRC, long sourceSSRC)
+    {
+        super(FMT, PSFB, senderSSRC, sourceSSRC);
+    }
+
+    /**
+     * Ctor to use when reading a PLI.
+     * @param base
+     */
+    public PLIPacket(RTCPCompoundPacket base)
+    {
+        super(base);
+        super.fmt = FMT;
+        super.type = PSFB;
+    }
+
+    /**
+     * Parses a PLI.
+     */
+    public static RTCPPacket parse(RTCPCompoundPacket base,
+        int firstbyte, int rtpfb, int length, DataInputStream in,
+        long senderSSRC, long sourceSSRC)
+    {
+        PLIPacket pliPacket = new PLIPacket(base);
+
+        // And we're done!
+
+        return pliPacket;
+    }
+}

--- a/src/org/jitsi/impl/neomedia/rtcp/RTCPFBPacket.java
+++ b/src/org/jitsi/impl/neomedia/rtcp/RTCPFBPacket.java
@@ -60,6 +60,16 @@ public class RTCPFBPacket
      */
     public long sourceSSRC;
 
+
+    public static void writeSsrc(DataOutputStream dataOutputStream, long ssrc)
+        throws IOException
+    {
+        dataOutputStream.writeByte((byte) (ssrc >> 24));
+        dataOutputStream.writeByte((byte) ((ssrc >> 16) & 0xFF));
+        dataOutputStream.writeByte((byte) ((ssrc >> 8) & 0xFF));
+        dataOutputStream.writeByte((byte) (ssrc & 0xFF));
+    }
+
     public RTCPFBPacket(int fmt, int type, long senderSSRC, long sourceSSRC)
     {
         super.type = type;

--- a/src/org/jitsi/impl/neomedia/rtcp/RTCPPacketParserEx.java
+++ b/src/org/jitsi/impl/neomedia/rtcp/RTCPPacketParserEx.java
@@ -165,6 +165,22 @@ public class RTCPPacketParserEx
                         remb.dest[i] = in.readInt() & 0xffffffffL;
 
                     return remb;
+                case FIRPacket.FMT:
+                    return FIRPacket.parse(base,
+                        firstbyte,
+                        type,
+                        length,
+                        in,
+                        senderSSRC,
+                        sourceSSRC);
+                case PLIPacket.FMT:
+                    return PLIPacket.parse(base,
+                        firstbyte,
+                        type,
+                        length,
+                        in,
+                        senderSSRC,
+                        sourceSSRC);
                 default:
                     return
                         parseRTCPFBPacket(

--- a/src/org/jitsi/impl/neomedia/rtp/RTCPListenerAdapter.java
+++ b/src/org/jitsi/impl/neomedia/rtp/RTCPListenerAdapter.java
@@ -13,19 +13,34 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jitsi.service.neomedia.rtp;
+package org.jitsi.impl.neomedia.rtp;
 
 import org.jitsi.impl.neomedia.rtcp.*;
+import org.jitsi.service.neomedia.rtp.*;
 
 /**
- * A simple interface for handling RTCP NACK packets.
- * @author Boris Grozev
+ * Convenience adapter that allows implementors to implement only some of the
+ * methods required by the {@code RTCPListener} interface.
+ *
+ * @author George Politis
  */
-public interface NACKListener
+public class RTCPListenerAdapter implements RTCPListener
 {
-    /**
-     * Handles an RTCP NACK packet.
-     * @param nackPacket the packet.
-     */
-    public void nackReceived(NACKPacket nackPacket);
+    @Override
+    public void nackReceived(NACKPacket nackPacket)
+    {
+
+    }
+
+    @Override
+    public void firReceived(FIRPacket fir)
+    {
+
+    }
+
+    @Override
+    public void pliReceived(PLIPacket pli)
+    {
+
+    }
 }

--- a/src/org/jitsi/impl/neomedia/transform/rtcp/StatisticsEngine.java
+++ b/src/org/jitsi/impl/neomedia/transform/rtcp/StatisticsEngine.java
@@ -1045,6 +1045,16 @@ public class StatisticsEngine
                     streamStats.rembReceived(remb);
                     out.add(rtcp);
                 }
+                else if (rtcp instanceof FIRPacket)
+                {
+                    FIRPacket fir = (FIRPacket) rtcp;
+                    streamStats.firReceived(fir);
+                }
+                else if (rtcp instanceof PLIPacket)
+                {
+                    PLIPacket pli = (PLIPacket) rtcp;
+                    streamStats.pliReceived(pli);
+                }
                 break;
 
             case RTCPPacket.RR:
@@ -1090,7 +1100,6 @@ public class StatisticsEngine
                     removed = true;
                 }
                 break;
-
             case RTCPExtendedReport.XR:
                 if (rtcp instanceof RTCPExtendedReport)
                 {

--- a/src/org/jitsi/service/neomedia/MediaStreamStats.java
+++ b/src/org/jitsi/service/neomedia/MediaStreamStats.java
@@ -361,7 +361,7 @@ public interface MediaStreamStats
      * Adds a listener which will be notified when NACK packets are received.
      * @param listener the listener.
      */
-    public void addNackListener(NACKListener listener);
+    public void addNackListener(RTCPListener listener);
 
     /**
      * Adds a listener which will be notified when REMB packets are received.

--- a/src/org/jitsi/service/neomedia/rtp/RTCPListener.java
+++ b/src/org/jitsi/service/neomedia/rtp/RTCPListener.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright @ 2015 Atlassian Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.service.neomedia.rtp;
+
+import org.jitsi.impl.neomedia.rtcp.*;
+
+/**
+ * A simple interface for handling RTCP NACK packets.
+ *
+ * @author Boris Grozev
+ * @author George Politis
+ */
+public interface RTCPListener
+{
+    /**
+     * Handles an RTCP NACK packet.
+     * @param nackPacket the packet.
+     */
+    public void nackReceived(NACKPacket nackPacket);
+
+    /**
+     * Handles an RTCP FIR packet.
+     * @param fir the packet.
+     */
+    void firReceived(FIRPacket fir);
+
+    /**
+     * Handles an RTCP PLI packet.
+     * @param pli the packet.
+     */
+    void pliReceived(PLIPacket pli);
+}


### PR DESCRIPTION
- Adds support for parsing FIRs and PLIs.
- Renames NACKListener to RTCPListener and extends it to fire events for FIRs and PLIs.

Note that this breaks the bridge (because of NACKListener -> RTCPListener)
