### PR TITLE
Enforce Perfect Forward Secrecy for DTLS

### DIFF
--- a/src/org/jitsi/impl/neomedia/transform/dtls/TlsClientImpl.java
+++ b/src/org/jitsi/impl/neomedia/transform/dtls/TlsClientImpl.java
@@ -94,24 +94,28 @@ public class TlsClientImpl
      * {@inheritDoc}
      *
      * Overrides the super implementation to explicitly specify cipher suites
-     * which we know to be supported by Bouncy Castle. At the time of this
-     * writing, we know that Bouncy Castle implements Client Key Exchange only
-     * with <tt>TLS_ECDHE_WITH_XXX</tt> and <tt>TLS_RSA_WITH_XXX</tt>.
+     * which we know to be supported by Bouncy Castle and provide Perfect
+     * Forward Secrecy.
      */
     @Override
     public int[] getCipherSuites()
     {
-        return
-            new int[]
-                    {
+        return new int[]
+        {
 /* core/src/main/java/org/bouncycastle/crypto/tls/DefaultTlsClient.java */
-                        CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-                        CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
-                        CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
-                        CipherSuite.TLS_RSA_WITH_AES_128_GCM_SHA256,
-                        CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA256,
-                        CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA
-                    };
+            CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+            CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
+            CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+            CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+            CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+            CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+            CipherSuite.TLS_DHE_DSS_WITH_AES_128_GCM_SHA256,
+            CipherSuite.TLS_DHE_DSS_WITH_AES_128_CBC_SHA256,
+            CipherSuite.TLS_DHE_DSS_WITH_AES_128_CBC_SHA,
+            CipherSuite.TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,
+            CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA256,
+            CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA,
+        };
     }
 
     /**

--- a/src/org/jitsi/impl/neomedia/transform/dtls/TlsServerImpl.java
+++ b/src/org/jitsi/impl/neomedia/transform/dtls/TlsServerImpl.java
@@ -104,36 +104,28 @@ public class TlsServerImpl
      * {@inheritDoc}
      *
      * Overrides the super implementation to explicitly specify cipher suites
-     * which we know to be supported by Bouncy Castle. At the time of this
-     * writing, we know that Bouncy Castle implements Client Key Exchange only
-     * with <tt>TLS_ECDHE_WITH_XXX</tt> and <tt>TLS_RSA_WITH_XXX</tt>.
+     * which we know to be supported by Bouncy Castle and provide Perfect
+     * Forward Secrecy.
      */
     @Override
     protected int[] getCipherSuites()
     {
-        return
-            new int[]
-                    {
+        return new int[]
+        {
 /* core/src/main/java/org/bouncycastle/crypto/tls/DefaultTlsServer.java */
-                        CipherSuite.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-                        CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-                        CipherSuite.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384,
-                        CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
-                        CipherSuite.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
-                        CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
-                        CipherSuite.TLS_RSA_WITH_AES_256_GCM_SHA384,
-                        CipherSuite.TLS_RSA_WITH_AES_128_GCM_SHA256,
-                        CipherSuite.TLS_RSA_WITH_AES_256_CBC_SHA256,
-                        CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA256,
-                        CipherSuite.TLS_RSA_WITH_AES_256_CBC_SHA,
-                        CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
-/* core/src/test/java/org/bouncycastle/crypto/tls/test/MockDTLSServer.java */
-                        CipherSuite.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
-                        CipherSuite.TLS_ECDHE_RSA_WITH_ESTREAM_SALSA20_SHA1,
-                        CipherSuite.TLS_ECDHE_RSA_WITH_SALSA20_SHA1,
-                        CipherSuite.TLS_RSA_WITH_ESTREAM_SALSA20_SHA1,
-                        CipherSuite.TLS_RSA_WITH_SALSA20_SHA1
-                    };
+            CipherSuite.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+            CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+            CipherSuite.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384,
+            CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+            CipherSuite.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+            CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+            CipherSuite.TLS_DHE_RSA_WITH_AES_256_GCM_SHA384,
+            CipherSuite.TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,
+            CipherSuite.TLS_DHE_RSA_WITH_AES_256_CBC_SHA256,
+            CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA256,
+            CipherSuite.TLS_DHE_RSA_WITH_AES_256_CBC_SHA,
+            CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA
+        };
     }
 
     /**


### PR DESCRIPTION
As discussed when we were implementing DTLS cert cache (#98),
we want to enforce Perfect Forward Secrecy,
so that server compromise as no effect on past conferences.

On the client side Firefox is already enforcing it since v38
https://hacks.mozilla.org/2015/02/webrtc-requires-perfect-forward-secrecy-pfs-starting-in-firefox-38/
(don't know about chrome)

Tested with Firefox 44, Firefox Nightly 47 and Chrome 49