### PR TITLE
Unbreak DTLS flights

### DIFF
--- a/src/org/jitsi/impl/neomedia/transform/dtls/CertificateInfo.java
+++ b/src/org/jitsi/impl/neomedia/transform/dtls/CertificateInfo.java
@@ -16,6 +16,7 @@
 package org.jitsi.impl.neomedia.transform.dtls;
 
 import org.bouncycastle.crypto.*;
+import org.bouncycastle.crypto.tls.*;
 
 /**
  * Bundles information such as key pair, hash function, fingerprint, etc. about
@@ -30,12 +31,12 @@ class CertificateInfo
      * The certificate with which the local endpoint represented by this
      * instance authenticates its ends of DTLS sessions.
      */
-    public final org.bouncycastle.crypto.tls.Certificate certificate;
+    private final Certificate certificate;
 
     /**
      * The private and public keys of {@link #certificate}.
      */
-    public final AsymmetricCipherKeyPair keyPair;
+    private final AsymmetricCipherKeyPair keyPair;
 
     /**
      * The fingerprint of {@link #certificate}.
@@ -55,9 +56,20 @@ class CertificateInfo
      */
     public final long timestamp;
 
+    /**
+     * Initializes a new {@code CertificateInfo} instance.
+     *
+     * @param keyPair the private and public keys of {@code certificate}
+     * @param certificate the certificate with which the local endpoint
+     * represented by the new instance is to authenticates its ends of DTLS
+     * sessions
+     * @param localFingerprintHashFunction
+     * @param localFingerprint
+     * @param timestamp
+     */
     public CertificateInfo(
             AsymmetricCipherKeyPair keyPair,
-            org.bouncycastle.crypto.tls.Certificate certificate,
+            Certificate certificate,
             String localFingerprintHashFunction,
             String localFingerprint,
             long timestamp)
@@ -67,5 +79,27 @@ class CertificateInfo
         this.localFingerprintHashFunction = localFingerprintHashFunction;
         this.localFingerprint = localFingerprint;
         this.timestamp = timestamp;
+    }
+
+    /**
+     * Gets the certificate with which the local endpoint represented by this
+     * instance authenticates its ends of DTLS sessions.
+     *
+     * @return the certificate with which the local endpoint represented by this
+     * instance authenticates its ends of DTLS sessions.
+     */
+    public Certificate getCertificate()
+    {
+        return certificate;
+    }
+
+    /**
+     * Gets the private and public keys of {@link #certificate}.
+     *
+     * @return the private and public keys of {@link #certificate}.
+     */
+    public AsymmetricCipherKeyPair getKeyPair()
+    {
+        return keyPair;
     }
 }

--- a/src/org/jitsi/impl/neomedia/transform/dtls/DatagramTransportImpl.java
+++ b/src/org/jitsi/impl/neomedia/transform/dtls/DatagramTransportImpl.java
@@ -509,8 +509,12 @@ public class DatagramTransportImpl
                 case HandshakeType.hello_request:
                 case HandshakeType.hello_verify_request:
                 case HandshakeType.server_hello_done:
+                    endOfFlight = true;
+                    break;
                 default:
                     endOfFlight = true;
+                    logger.warn(
+                            "Unknown DTLS handshake message type: " + msg_type);
                     break;
                 }
                 // Do fall through!

--- a/src/org/jitsi/impl/neomedia/transform/dtls/DatagramTransportImpl.java
+++ b/src/org/jitsi/impl/neomedia/transform/dtls/DatagramTransportImpl.java
@@ -482,7 +482,15 @@ public class DatagramTransportImpl
             switch (type)
             {
             case ContentType.handshake:
-                short msg_type = TlsUtils.readUint8(buf, off + 11);
+                short msg_type
+                    = TlsUtils.readUint8(
+                            buf,
+                            off
+                                + 1 /* type */
+                                + 2 /* version */
+                                + 2 /* epoch */
+                                + 6 /* sequence_number */
+                                + 2 /* length */);
 
                 switch (msg_type)
                 {

--- a/src/org/jitsi/impl/neomedia/transform/dtls/DtlsControlImpl.java
+++ b/src/org/jitsi/impl/neomedia/transform/dtls/DtlsControlImpl.java
@@ -656,25 +656,41 @@ public class DtlsControlImpl
 
     /**
      * Gets the certificate with which the local endpoint represented by this
-     * instance authenticates its ends of DTLS sessions.
+     * instance authenticates its ends of DTLS sessions. Equivalent to
+     * {@code getCertificateInfo().getCertificate()}.
      *
      * @return the certificate with which the local endpoint represented by this
      * instance authenticates its ends of DTLS sessions.
      */
     org.bouncycastle.crypto.tls.Certificate getCertificate()
     {
-        return certificateInfo.certificate;
+        return getCertificateInfo().getCertificate();
+    }
+
+    /**
+     * Gets the certificate, hash function, fingerprint, etc. with which the
+     * local endpoint represented by this instance authenticates its ends of
+     * DTLS sessions.
+     *
+     * @return the certificate, hash function, fingerprint, etc. with which the
+     * local endpoint represented by this instance authenticates its ends of
+     * DTLS sessions
+     */
+    CertificateInfo getCertificateInfo()
+    {
+        return certificateInfo;
     }
 
     /**
      * The private and public keys of the <tt>certificate</tt> of this instance.
+     * Equivalent to {@code getCertificateInfo().getKeyPair()}.
      *
      * @return the private and public keys of the <tt>certificate</tt> of this
      * instance
      */
     AsymmetricCipherKeyPair getKeyPair()
     {
-        return certificateInfo.keyPair;
+        return getCertificateInfo().getKeyPair();
     }
 
     /**
@@ -683,7 +699,7 @@ public class DtlsControlImpl
     @Override
     public String getLocalFingerprint()
     {
-        return certificateInfo.localFingerprint;
+        return getCertificateInfo().localFingerprint;
     }
 
     /**
@@ -692,7 +708,7 @@ public class DtlsControlImpl
     @Override
     public String getLocalFingerprintHashFunction()
     {
-        return certificateInfo.localFingerprintHashFunction;
+        return getCertificateInfo().localFingerprintHashFunction;
     }
 
     /**

--- a/src/org/jitsi/impl/neomedia/transform/dtls/DtlsControlImpl.java
+++ b/src/org/jitsi/impl/neomedia/transform/dtls/DtlsControlImpl.java
@@ -522,18 +522,6 @@ public class DtlsControlImpl
     private final CertificateInfo certificateInfo;
 
     /**
-     * The <tt>RTPConnector</tt> which uses the <tt>TransformEngine</tt> of this
-     * <tt>SrtpControl</tt>.
-     */
-    private AbstractRTPConnector connector;
-
-    /**
-     * Indicates whether this <tt>DtlsControl</tt> will work in DTLS/SRTP or
-     * DTLS mode.
-     */
-    private final boolean disableSRTP;
-
-    /**
      * The indicator which determines whether this instance has been disposed
      * i.e. prepared for garbage collection by {@link #doCleanup()}.
      */
@@ -544,24 +532,7 @@ public class DtlsControlImpl
      */
     private Map<String,String> remoteFingerprints;
 
-    /**
-     * Whether rtcp-mux is in use.
-     */
-    private boolean rtcpmux = false;
-
-    /**
-     * The value of the <tt>setup</tt> SDP attribute defined by RFC 4145
-     * &quot;TCP-Based Media Transport in the Session Description Protocol
-     * (SDP)&quot; which determines whether this instance acts as a DTLS client
-     * or a DTLS server.
-     */
-    private Setup setup;
-
-    /**
-     * The instances currently registered as users of this <tt>SrtpControl</tt>
-     * (through {@link #registerUser(Object)}).
-     */
-    private final Set<Object> users = new HashSet<>();
+    private final Properties properties;
 
     /**
      * Initializes a new <tt>DtlsControlImpl</tt> instance.
@@ -569,19 +540,18 @@ public class DtlsControlImpl
     public DtlsControlImpl()
     {
         // By default we work in DTLS/SRTP mode.
-        this(false);
+        this(/* srtpDisabled */ false);
     }
 
     /**
      * Initializes a new <tt>DtlsControlImpl</tt> instance.
-     * @param disableSRTP <tt>true</tt> if pure DTLS mode without SRTP
-     *                    extensions should be used.
+     *
+     * @param srtpDisabled <tt>true</tt> if pure DTLS mode without SRTP
+     * extensions is to be used; otherwise, <tt>false</tt>
      */
-    public DtlsControlImpl(boolean disableSRTP)
+    public DtlsControlImpl(boolean srtpDisabled)
     {
         super(SrtpControlType.DTLS_SRTP);
-
-        this.disableSRTP = disableSRTP;
 
         CertificateInfo certificateInfo;
 
@@ -605,19 +575,8 @@ public class DtlsControlImpl
             }
         }
         this.certificateInfo = certificateInfo;
-    }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void cleanup(Object user)
-    {
-        synchronized (users)
-        {
-            if (users.remove(user) && users.isEmpty())
-                doCleanup();
-        }
+        properties = new Properties(srtpDisabled);
     }
 
     /**
@@ -630,20 +589,16 @@ public class DtlsControlImpl
     @Override
     protected DtlsTransformEngine createTransformEngine()
     {
-        DtlsTransformEngine transformEngine = new DtlsTransformEngine(this);
-
-        transformEngine.setConnector(connector);
-        transformEngine.setSetup(setup);
-        transformEngine.setRtcpmux(rtcpmux);
-        return transformEngine;
+        return new DtlsTransformEngine(this);
     }
 
     /**
-     * Prepares this <tt>DtlsControlImpl</tt> for garbage collection.
+     * {@inheritDoc}
      */
-    private void doCleanup()
+    @Override
+    protected void doCleanup()
     {
-        super.cleanup(null);
+        super.doCleanup();
 
         setConnector(null);
 
@@ -652,19 +607,6 @@ public class DtlsControlImpl
             disposed = true;
             notifyAll();
         }
-    }
-
-    /**
-     * Gets the certificate with which the local endpoint represented by this
-     * instance authenticates its ends of DTLS sessions. Equivalent to
-     * {@code getCertificateInfo().getCertificate()}.
-     *
-     * @return the certificate with which the local endpoint represented by this
-     * instance authenticates its ends of DTLS sessions.
-     */
-    org.bouncycastle.crypto.tls.Certificate getCertificate()
-    {
-        return getCertificateInfo().getCertificate();
     }
 
     /**
@@ -679,18 +621,6 @@ public class DtlsControlImpl
     CertificateInfo getCertificateInfo()
     {
         return certificateInfo;
-    }
-
-    /**
-     * The private and public keys of the <tt>certificate</tt> of this instance.
-     * Equivalent to {@code getCertificateInfo().getKeyPair()}.
-     *
-     * @return the private and public keys of the <tt>certificate</tt> of this
-     * instance
-     */
-    AsymmetricCipherKeyPair getKeyPair()
-    {
-        return getCertificateInfo().getKeyPair();
     }
 
     /**
@@ -711,6 +641,11 @@ public class DtlsControlImpl
         return getCertificateInfo().localFingerprintHashFunction;
     }
 
+    Properties getProperties()
+    {
+        return properties;
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -719,28 +654,6 @@ public class DtlsControlImpl
     {
         // TODO Auto-generated method stub
         return false;
-    }
-
-    /**
-     * Indicates if SRTP extensions are disabled which means we're working in
-     * pure DTLS mode.
-     * @return <tt>true</tt> if SRTP extensions must be disabled.
-     */
-    boolean isSrtpDisabled()
-    {
-        return disableSRTP;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void registerUser(Object user)
-    {
-        synchronized (users)
-        {
-            users.add(user);
-        }
     }
 
     /**
@@ -761,15 +674,7 @@ public class DtlsControlImpl
     @Override
     public void setConnector(AbstractRTPConnector connector)
     {
-        if (this.connector != connector)
-        {
-            this.connector = connector;
-
-            DtlsTransformEngine transformEngine = this.transformEngine;
-
-            if (transformEngine != null)
-                transformEngine.setConnector(this.connector);
-        }
+        properties.put(Properties.CONNECTOR_PNAME, connector);
     }
 
     /**
@@ -781,32 +686,27 @@ public class DtlsControlImpl
         if (remoteFingerprints == null)
             throw new NullPointerException("remoteFingerprints");
 
-        synchronized (this)
+        // Make sure that the hash functions (which are keys of the field
+        // remoteFingerprints) are written in lower case.
+        Map<String,String> rfs = new HashMap<>(remoteFingerprints.size());
+
+        for (Map.Entry<String,String> e : remoteFingerprints.entrySet())
         {
-            // Make sure that the hash functions (which are keys of the field
-            // remoteFingerprints) are written in lower case.
-            Map<String,String> rfs = new HashMap<>(remoteFingerprints.size());
+            String k = e.getKey();
 
-            for (Map.Entry<String,String> e : remoteFingerprints.entrySet())
+            // It makes no sense to provide a fingerprint without a hash
+            // function.
+            if (k != null)
             {
-                String k = e.getKey();
+                String v = e.getValue();
 
-                // It makes no sense to provide a fingerprint without a hash
-                // function.
-                if (k != null)
-                {
-                    String v = e.getValue();
-
-                    // It makes no sense to provide a hash function without a
-                    // fingerprint.
-                    if (v != null)
-                        rfs.put(k.toLowerCase(), v);
-                }
+                // It makes no sense to provide a hash function without a
+                // fingerprint.
+                if (v != null)
+                    rfs.put(k.toLowerCase(), v);
             }
-            this.remoteFingerprints = rfs;
-
-            notifyAll();
         }
+        this.remoteFingerprints = rfs;
     }
 
     /**
@@ -815,15 +715,7 @@ public class DtlsControlImpl
     @Override
     public void setRtcpmux(boolean rtcpmux)
     {
-        if (this.rtcpmux != rtcpmux)
-        {
-            this.rtcpmux = rtcpmux;
-
-            DtlsTransformEngine transformEngine = this.transformEngine;
-
-            if (transformEngine != null)
-                transformEngine.setRtcpmux(rtcpmux);
-        }
+        properties.put(Properties.RTCPMUX_PNAME, rtcpmux);
     }
 
     /**
@@ -832,15 +724,7 @@ public class DtlsControlImpl
     @Override
     public void setSetup(Setup setup)
     {
-        if (this.setup != setup)
-        {
-            this.setup = setup;
-
-            DtlsTransformEngine transformEngine = this.transformEngine;
-
-            if (transformEngine != null)
-                transformEngine.setSetup(this.setup);
-        }
+        properties.put(Properties.SETUP_PNAME, setup);
     }
 
     /**
@@ -849,10 +733,7 @@ public class DtlsControlImpl
     @Override
     public void start(MediaType mediaType)
     {
-        DtlsTransformEngine transformEngine = getTransformEngine();
-
-        if (transformEngine != null)
-            transformEngine.start(mediaType);
+        properties.put(Properties.MEDIA_TYPE_PNAME, mediaType);
     }
 
     /**

--- a/src/org/jitsi/impl/neomedia/transform/dtls/DtlsControlImpl.java
+++ b/src/org/jitsi/impl/neomedia/transform/dtls/DtlsControlImpl.java
@@ -532,6 +532,11 @@ public class DtlsControlImpl
      */
     private Map<String,String> remoteFingerprints;
 
+    /**
+     * The properties of {@code DtlsControlImpl} and their values which this
+     * instance shares with {@link DtlsTransformEngine} and
+     * {@link DtlsPacketTransformer}.
+     */
     private final Properties properties;
 
     /**
@@ -581,7 +586,8 @@ public class DtlsControlImpl
 
     /**
      * Initializes a new <tt>DtlsTransformEngine</tt> instance to be associated
-     * with and used by this <tt>DtlsControlImpl</tt> instance.
+     * with and used by this <tt>DtlsControlImpl</tt> instance. The method is
+     * implemented as a factory.
      *
      * @return a new <tt>DtlsTransformEngine</tt> instance to be associated with
      * and used by this <tt>DtlsControlImpl</tt> instance
@@ -641,6 +647,15 @@ public class DtlsControlImpl
         return getCertificateInfo().localFingerprintHashFunction;
     }
 
+    /**
+     * Gets the properties of {@code DtlsControlImpl} and their values which
+     * this instance shares with {@link DtlsTransformEngine} and
+     * {@link DtlsPacketTransformer}.
+     *
+     * @return the properties of {@code DtlsControlImpl} and their values which
+     * this instance shares with {@code DtlsTransformEngine} and
+     * {@code DtlsPacketTransformer}
+     */
     Properties getProperties()
     {
         return properties;

--- a/src/org/jitsi/impl/neomedia/transform/dtls/DtlsControlImpl.java
+++ b/src/org/jitsi/impl/neomedia/transform/dtls/DtlsControlImpl.java
@@ -657,6 +657,22 @@ public class DtlsControlImpl
     }
 
     /**
+     * Gets the value of the {@code setup} SDP attribute defined by RFC 4145
+     * &quot;TCP-Based Media Transport in the Session Description Protocol
+     * (SDP)&quot; which determines whether this instance acts as a DTLS client
+     * or a DTLS server.
+     *
+     * @return the value of the {@code setup} SDP attribute defined by RFC 4145
+     * &quot;TCP-Based Media Transport in the Session Description Protocol
+     * (SDP)&quot; which determines whether this instance acts as a DTLS client
+     * or a DTLS server
+     */
+    public DtlsControl.Setup getSetup()
+    {
+        return getProperties().getSetup();
+    }
+
+    /**
      * {@inheritDoc}
      *
      * The implementation of <tt>DtlsControlImpl</tt> always returns

--- a/src/org/jitsi/impl/neomedia/transform/dtls/DtlsPacketTransformer.java
+++ b/src/org/jitsi/impl/neomedia/transform/dtls/DtlsPacketTransformer.java
@@ -381,6 +381,13 @@ public class DtlsPacketTransformer
         return getTransformEngine().getDtlsControl();
     }
 
+    /**
+     * Gets the properties of {@link DtlsControlImpl} and their values which
+     * the associated {@code DtlsControlImpl} shares with this instance.
+     *
+     * @return the properties of {@code DtlsControlImpl} and their values which
+     * the associated {@code DtlsControlImpl} shares with this instance
+     */
     Properties getProperties()
     {
         return getTransformEngine().getProperties();
@@ -1138,6 +1145,7 @@ public class DtlsPacketTransformer
         if (this.connector != connector)
         {
             AbstractRTPConnector oldValue = this.connector;
+
             this.connector = connector;
 
             DatagramTransportImpl datagramTransport = this.datagramTransport;

--- a/src/org/jitsi/impl/neomedia/transform/dtls/DtlsPacketTransformer.java
+++ b/src/org/jitsi/impl/neomedia/transform/dtls/DtlsPacketTransformer.java
@@ -15,6 +15,7 @@
  */
 package org.jitsi.impl.neomedia.transform.dtls;
 
+import java.beans.*;
 import java.io.*;
 import java.security.*;
 import java.util.*;
@@ -28,6 +29,7 @@ import org.jitsi.service.configuration.*;
 import org.jitsi.service.libjitsi.*;
 import org.jitsi.service.neomedia.*;
 import org.jitsi.util.*;
+import org.jitsi.util.event.*;
 
 /**
  * Implements {@link PacketTransformer} for DTLS-SRTP. It's capable of working
@@ -205,6 +207,17 @@ public class DtlsPacketTransformer
      */
     private MediaType mediaType;
 
+    private final PropertyChangeListener propertyChangeListener
+        = new WeakReferencePropertyChangeListener(
+                new PropertyChangeListener()
+                {
+                    @Override
+                    public void propertyChange(PropertyChangeEvent ev)
+                    {
+                        DtlsPacketTransformer.this.propertyChange(ev);
+                    }
+                });
+
     /**
      * The {@code Queue} of SRTP {@code RawPacket}s which were received from the
      * remote while {@link #_srtpTransformer} was unavailable i.e. {@code null}.
@@ -219,15 +232,7 @@ public class DtlsPacketTransformer
      * a DTLS session on its own, but rather wait for the RTP transformer to
      * do so, and reuse it to initialize the SRTP transformer.
      */
-    private boolean rtcpmux = false;
-
-    /**
-     * The value of the <tt>setup</tt> SDP attribute defined by RFC 4145
-     * &quot;TCP-Based Media Transport in the Session Description Protocol
-     * (SDP)&quot; which determines whether this instance acts as a DTLS client
-     * or a DTLS server.
-     */
-    private DtlsControl.Setup setup;
+    private boolean rtcpmux;
 
     /**
      * The {@code SRTPTransformer} (to be) used by this instance.
@@ -269,6 +274,11 @@ public class DtlsPacketTransformer
     {
         this.transformEngine = transformEngine;
         this.componentID = componentID;
+
+        // Track the DTLS properties which control the conditional behaviors of
+        // DtlsPacketTransformer.
+        getProperties().addPropertyChangeListener(propertyChangeListener);
+        propertyChange(/* propertyName */ (String) null);
     }
 
     /**
@@ -277,6 +287,8 @@ public class DtlsPacketTransformer
     @Override
     public synchronized void close()
     {
+        getProperties().removePropertyChangeListener(propertyChangeListener);
+
         // SrtpControl.start(MediaType) starts its associated TransformEngine.
         // We will use that mediaType to signal the normal stop then as well
         // i.e. we will call setMediaType(null) first.
@@ -367,6 +379,11 @@ public class DtlsPacketTransformer
     DtlsControlImpl getDtlsControl()
     {
         return getTransformEngine().getDtlsControl();
+    }
+
+    Properties getProperties()
+    {
+        return getTransformEngine().getProperties();
     }
 
     /**
@@ -708,6 +725,18 @@ public class DtlsPacketTransformer
         return srtpTransformer;
     }
 
+    /**
+     * Determines whether this {@code DtlsPacketTransformer} is to operate in
+     * pure DTLS mode without SRTP extensions or in DTLS/SRTP mode.
+     *
+     * @return {@code true} for pure DTLS without SRTP extensions or
+     * {@code false} for DTLS/SRTP
+     */
+    private boolean isSrtpDisabled()
+    {
+        return getProperties().isSrtpDisabled();
+    }
+
     private synchronized void maybeStart()
     {
         if (this.mediaType != null && this.connector != null && !started)
@@ -740,6 +769,38 @@ public class DtlsPacketTransformer
                 && AlertDescription.close_notify == alertDescription)
         {
             tlsPeerHasRaisedCloseNotifyWarning = true;
+        }
+    }
+
+    private void propertyChange(PropertyChangeEvent ev)
+    {
+        propertyChange(ev.getPropertyName());
+    }
+
+    private void propertyChange(String propertyName)
+    {
+        // This DtlsPacketTransformer calls the method with null at construction
+        // time to initialize the respective states.
+        if (propertyName == null)
+        {
+            propertyChange(Properties.RTCPMUX_PNAME);
+            propertyChange(Properties.MEDIA_TYPE_PNAME);
+            propertyChange(Properties.CONNECTOR_PNAME);
+        }
+        else if (Properties.CONNECTOR_PNAME.equals(propertyName))
+        {
+            setConnector(
+                    (AbstractRTPConnector) getProperties().get(propertyName));
+        }
+        else if (Properties.MEDIA_TYPE_PNAME.equals(propertyName))
+        {
+            setMediaType((MediaType) getProperties().get(propertyName));
+        }
+        else if (Properties.RTCPMUX_PNAME.equals(propertyName))
+        {
+            Object newValue = getProperties().get(propertyName);
+
+            setRtcpmux((newValue == null) ? false : (Boolean) newValue);
         }
     }
 
@@ -918,7 +979,7 @@ public class DtlsPacketTransformer
             DatagramTransport datagramTransport)
     {
         DTLSTransport dtlsTransport = null;
-        final boolean srtp = !transformEngine.isSrtpDisabled();
+        final boolean srtp = !isSrtpDisabled();
         int srtpProtectionProfile = 0;
         TlsContext tlsContext = null;
 
@@ -1072,7 +1133,7 @@ public class DtlsPacketTransformer
      * @param connector the <tt>RTPConnector</tt> which is to use or uses this
      * <tt>PacketTransformer</tt>
      */
-    void setConnector(AbstractRTPConnector connector)
+    private void setConnector(AbstractRTPConnector connector)
     {
         if (this.connector != connector)
         {
@@ -1096,7 +1157,7 @@ public class DtlsPacketTransformer
      * @param mediaType the <tt>MediaType</tt> of the stream which this instance
      * is to work for/be associated with
      */
-    synchronized void setMediaType(MediaType mediaType)
+    private synchronized void setMediaType(MediaType mediaType)
     {
         if (this.mediaType != mediaType)
         {
@@ -1113,26 +1174,13 @@ public class DtlsPacketTransformer
 
     /**
      * Enables/disables rtcp-mux.
-     * @param rtcpmux whether to enable or disable.
+     *
+     * @param rtcpmux {@code true} to enable rtcp-mux or {@code false} to
+     * disable it.
      */
     void setRtcpmux(boolean rtcpmux)
     {
         this.rtcpmux = rtcpmux;
-    }
-
-    /**
-     * Sets the DTLS protocol according to which this
-     * <tt>DtlsPacketTransformer</tt> is to act either as a DTLS server or a
-     * DTLS client.
-     *
-     * @param setup the value of the <tt>setup</tt> SDP attribute to set on this
-     * instance in order to determine whether this instance is to act as a DTLS
-     * client or a DTLS server
-     */
-    void setSetup(DtlsControl.Setup setup)
-    {
-        if (this.setup != setup)
-            this.setup = setup;
     }
 
     /**
@@ -1167,7 +1215,7 @@ public class DtlsPacketTransformer
         if (connector == null)
             throw new NullPointerException("connector");
 
-        DtlsControl.Setup setup = this.setup;
+        DtlsControl.Setup setup = getProperties().getSetup();
         SecureRandom secureRandom = DtlsControlImpl.createSecureRandom();
         final DTLSProtocol dtlsProtocolObj;
         final TlsPeer tlsPeer;
@@ -1402,7 +1450,7 @@ public class DtlsPacketTransformer
             boolean transform,
             List<RawPacket> outPkts)
     {
-        /* Pure/non-SRTP DTLS */ if (transformEngine.isSrtpDisabled())
+        /* Pure/non-SRTP DTLS */ if (isSrtpDisabled())
         {
             // (1) In the incoming/reverseTransform direction, only DTLS records
             // pass through.

--- a/src/org/jitsi/impl/neomedia/transform/dtls/DtlsTransformEngine.java
+++ b/src/org/jitsi/impl/neomedia/transform/dtls/DtlsTransformEngine.java
@@ -30,11 +30,6 @@ public class DtlsTransformEngine
     implements SrtpControl.TransformEngine
 {
     /**
-     * The <tt>RTPConnector</tt> which uses this <tt>TransformEngine</tt>.
-     */
-    private AbstractRTPConnector connector;
-
-    /**
      * The indicator which determines whether
      * {@link SrtpControl.TransformEngine#cleanup()} has been invoked on this
      * instance to prepare it for garbage collection.
@@ -47,34 +42,11 @@ public class DtlsTransformEngine
     private final DtlsControlImpl dtlsControl;
 
     /**
-     * The <tt>MediaType</tt> of the stream which this instance works for/is
-     * associated with.
-     */
-    private MediaType mediaType;
-
-    /**
      * The <tt>PacketTransformer</tt>s of this <tt>TransformEngine</tt> for
      * data/RTP and control/RTCP packets.
      */
     private final DtlsPacketTransformer[] packetTransformers
         = new DtlsPacketTransformer[2];
-
-    /**
-     * Whether rtcp-mux is in use.
-     *
-     * When enabled, the <tt>DtlsPacketTransformer</tt> will, instead of
-     * establishing a DTLS session, wait for the transformer for RTP to
-     * establish one, and reuse it to initialize its SRTP transformer.
-     */
-    private boolean rtcpmux = false;
-
-    /**
-     * The value of the <tt>setup</tt> SDP attribute defined by RFC 4145
-     * &quot;TCP-Based Media Transport in the Session Description Protocol
-     * (SDP)&quot; which determines whether this instance acts as a DTLS client
-     * or a DTLS server.
-     */
-    private DtlsControl.Setup setup;
 
     /**
      * Initializes a new <tt>DtlsTransformEngine</tt> instance.
@@ -92,13 +64,6 @@ public class DtlsTransformEngine
     {
         disposed = true;
 
-        /*
-         * SrtpControl.start(MediaType) starts its associated TransformEngine.
-         * We will use that mediaType to signal the normal stop then as well
-         * i.e. we will call setMediaType(null) first.
-         */
-        setMediaType(null);
-
         for (int i = 0; i < packetTransformers.length; i++)
         {
             DtlsPacketTransformer packetTransformer = packetTransformers[i];
@@ -109,8 +74,6 @@ public class DtlsTransformEngine
                 packetTransformers[i] = null;
             }
         }
-
-        setConnector(null);
     }
 
     /**
@@ -124,14 +87,7 @@ public class DtlsTransformEngine
      */
     private DtlsPacketTransformer createPacketTransformer(int componentID)
     {
-        DtlsPacketTransformer packetTransformer
-            = new DtlsPacketTransformer(this, componentID);
-
-        packetTransformer.setConnector(connector);
-        packetTransformer.setSetup(setup);
-        packetTransformer.setRtcpmux(rtcpmux);
-        packetTransformer.setMediaType(mediaType);
-        return packetTransformer;
+        return new DtlsPacketTransformer(this, componentID);
     }
 
     /**
@@ -167,6 +123,11 @@ public class DtlsTransformEngine
         return packetTransformer;
     }
 
+    Properties getProperties()
+    {
+        return getDtlsControl().getProperties();
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -181,109 +142,5 @@ public class DtlsTransformEngine
     public PacketTransformer getRTPTransformer()
     {
         return getPacketTransformer(Component.RTP);
-    }
-
-    /**
-     * Indicates if SRTP extensions should be disabled which means we are
-     * currently working in pure DTLS mode.
-     * @return <tt>true</tt> if SRTP extensions should be disabled.
-     */
-    boolean isSrtpDisabled()
-    {
-        return dtlsControl.isSrtpDisabled();
-    }
-
-    /**
-     * Sets the <tt>RTPConnector</tt> which is to use or uses this
-     * <tt>TransformEngine</tt>.
-     *
-     * @param connector the <tt>RTPConnector</tt> which is to use or uses this
-     * <tt>TransformEngine</tt>
-     */
-    void setConnector(AbstractRTPConnector connector)
-    {
-        if (this.connector != connector)
-        {
-            this.connector = connector;
-
-            for (DtlsPacketTransformer packetTransformer : packetTransformers)
-            {
-                if (packetTransformer != null)
-                    packetTransformer.setConnector(this.connector);
-            }
-        }
-    }
-
-    /**
-     * Sets the <tt>MediaType</tt> of the stream which this instance is to work
-     * for/be associated with.
-     *
-     * @param mediaType the <tt>MediaType</tt> of the stream which this instance
-     * is to work for/be associated with
-     */
-    private void setMediaType(MediaType mediaType)
-    {
-        if (this.mediaType != mediaType)
-        {
-            this.mediaType = mediaType;
-
-            for (DtlsPacketTransformer packetTransformer : packetTransformers)
-            {
-                if (packetTransformer != null)
-                    packetTransformer.setMediaType(this.mediaType);
-            }
-        }
-    }
-
-    /**
-     * Enables/disables rtcp-mux.
-     * @param rtcpmux whether to enable or disable.
-     */
-    void setRtcpmux(boolean rtcpmux)
-    {
-        if (this.rtcpmux != rtcpmux)
-        {
-            this.rtcpmux = rtcpmux;
-
-            for (DtlsPacketTransformer packetTransformer : packetTransformers)
-            {
-                if (packetTransformer != null)
-                    packetTransformer.setRtcpmux(rtcpmux);
-            }
-        }
-    }
-
-    /**
-     * Sets the DTLS protocol according to which this
-     * <tt>DtlsTransformEngine</tt> is to act either as a DTLS server or a DTLS
-     * client.
-     *
-     * @param setup the value of the <tt>setup</tt> SDP attribute to set on this
-     * instance in order to determine whether this instance is to act as a DTLS
-     * client or a DTLS server
-     */
-    void setSetup(DtlsControl.Setup setup)
-    {
-        if (this.setup != setup)
-        {
-            this.setup = setup;
-
-            for (DtlsPacketTransformer packetTransformer : packetTransformers)
-            {
-                if (packetTransformer != null)
-                    packetTransformer.setSetup(this.setup);
-            }
-        }
-    }
-
-    /**
-     * Starts this instance in the sense that it becomes fully operational.
-     *
-     * @param mediaType the <tt>MediaType</tt> of the stream which this instance
-     * is to work for/be associated with
-     */
-    void start(MediaType mediaType)
-    {
-        setMediaType(mediaType);
     }
 }

--- a/src/org/jitsi/impl/neomedia/transform/dtls/DtlsTransformEngine.java
+++ b/src/org/jitsi/impl/neomedia/transform/dtls/DtlsTransformEngine.java
@@ -78,14 +78,15 @@ public class DtlsTransformEngine
 
     /**
      * Initializes a new <tt>DtlsPacketTransformer</tt> instance which is to
-     * work on control/RTCP or data/RTP packets.
+     * work on control/RTCP or data/RTP packets. The method is implemented as a
+     * factory.
      *
      * @param componentID the ID of the component for which the new instance is
      * to work
      * @return a new <tt>DtlsPacketTransformer</tt> instance which is to work on
      * control/RTCP or data/RTP packets (in accord with <tt>data</tt>)
      */
-    private DtlsPacketTransformer createPacketTransformer(int componentID)
+    protected DtlsPacketTransformer createPacketTransformer(int componentID)
     {
         return new DtlsPacketTransformer(this, componentID);
     }
@@ -123,6 +124,15 @@ public class DtlsTransformEngine
         return packetTransformer;
     }
 
+    /**
+     * Gets the properties of {@code DtlsControlImpl} and their values which
+     * {@link #dtlsControl} shares with this instance and
+     * {@link DtlsPacketTransformer}.
+     *
+     * @return the properties of {@code DtlsControlImpl} and their values which
+     * {@code dtlsControl} shares with this instance and
+     * {@code DtlsPacketTransformer}
+     */
     Properties getProperties()
     {
         return getDtlsControl().getProperties();

--- a/src/org/jitsi/impl/neomedia/transform/dtls/Properties.java
+++ b/src/org/jitsi/impl/neomedia/transform/dtls/Properties.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright @ 2015 Atlassian Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.impl.neomedia.transform.dtls;
+
+import java.util.*;
+import java.util.concurrent.*;
+
+import org.jitsi.service.neomedia.*;
+import org.jitsi.util.event.*;
+
+/**
+ * Gathers properties of {@link DtlsControlImpl} which it shares with
+ * {@link DtlsTransformEngine} and {@link DtlsPacketTransformer} i.e. assigning
+ * a value to a {@code DtlsControlImpl} property triggers assignments to the
+ * respective properties of {@code DtlsTransformEngine} and
+ * {@code DtlsPacketTransfomer}.
+ *
+ * @author Lyubomir Marinov
+ */
+class Properties
+    extends PropertyChangeNotifier
+{
+    /**
+     * The <tt>RTPConnector</tt> which uses the <tt>TransformEngine</tt> of this
+     * <tt>SrtpControl</tt>.
+     */
+    public static final String CONNECTOR_PNAME
+        = Properties.class.getName() + ".connector";
+
+    public static final String MEDIA_TYPE_PNAME
+        = Properties.class.getName() + ".mediaType";
+
+    /**
+     * Whether rtcp-mux is in use.
+     */
+    public static final String RTCPMUX_PNAME
+        = Properties.class.getName() + ".rtcpmux";
+
+    /**
+     * The value of the <tt>setup</tt> SDP attribute defined by RFC 4145
+     * &quot;TCP-Based Media Transport in the Session Description Protocol
+     * (SDP)&quot; which determines whether this instance acts as a DTLS client
+     * or a DTLS server.
+     */
+    public static final String SETUP_PNAME
+        = Properties.class.getName() + ".setup";
+
+    /**
+     * The actual {@code Map} of property names to property values represented
+     * by this instance. Stores only assignable properties i.e. {@code final}s
+     * are explicitly defined (e.g. {@link #srtpDisabled}).
+     */
+    private final Map<String,Object> properties = new ConcurrentHashMap<>();
+
+    /**
+     * Indicates whether this <tt>DtlsControl</tt> will work in DTLS/SRTP or
+     * pure DTLS mode.
+     */
+    private final boolean srtpDisabled;
+
+    /**
+     * Initializes a new {@code Properties} instance.
+     *
+     * @param srtpDisabled {@code true} to specify pure DTLS without SRTP
+     * extensions or {@code false} to specify DTLS/SRTP.
+     */
+    public Properties(boolean srtpDisabled)
+    {
+        this.srtpDisabled = srtpDisabled;
+    }
+
+    public Object get(String name)
+    {
+        return properties.get(name);
+    }
+
+    public DtlsControl.Setup getSetup()
+    {
+        return (DtlsControl.Setup) get(SETUP_PNAME);
+    }
+
+    /**
+     * Indicates if SRTP extensions are disabled which means we're working in
+     * pure DTLS mode.
+     *
+     * @return <tt>true</tt> if SRTP extensions must be disabled.
+     */
+    public boolean isSrtpDisabled()
+    {
+        return srtpDisabled;
+    }
+
+    public void put(String name, Object value)
+    {
+        Object oldValue = properties.put(name, value);
+        boolean equals
+            = (oldValue == null) ? (value == null) : oldValue.equals(value);
+
+        if (!equals)
+            firePropertyChange(name, oldValue, value);
+    }
+}

--- a/src/org/jitsi/impl/neomedia/transform/dtls/Properties.java
+++ b/src/org/jitsi/impl/neomedia/transform/dtls/Properties.java
@@ -82,11 +82,28 @@ class Properties
         this.srtpDisabled = srtpDisabled;
     }
 
+    /**
+     * Gets the value of the property with a specific name.
+     *
+     * @param name the name of the property to get the value of
+     * @return the value of the property with the specified {@code name}
+     */
     public Object get(String name)
     {
         return properties.get(name);
     }
 
+    /**
+     * Gets the value of the <tt>setup</tt> SDP attribute defined by RFC 4145
+     * &quot;TCP-Based Media Transport in the Session Description Protocol
+     * (SDP)&quot; which determines whether this instance acts as a DTLS client
+     * or a DTLS server.
+     *
+     * @return the value of the <tt>setup</tt> SDP attribute defined by RFC 4145
+     * &quot;TCP-Based Media Transport in the Session Description Protocol
+     * (SDP)&quot; which determines whether this instance acts as a DTLS client
+     * or a DTLS server.
+     */
     public DtlsControl.Setup getSetup()
     {
         return (DtlsControl.Setup) get(SETUP_PNAME);
@@ -103,6 +120,13 @@ class Properties
         return srtpDisabled;
     }
 
+    /**
+     * Sets the value of the property with a specific name.
+     *
+     * @param name the name of the property to set the value of
+     * @param value the value to set on the property with the specified
+     * {@code name}
+     */
     public void put(String name, Object value)
     {
         Object oldValue = properties.put(name, value);

--- a/src/org/jitsi/impl/neomedia/transform/dtls/TlsClientImpl.java
+++ b/src/org/jitsi/impl/neomedia/transform/dtls/TlsClientImpl.java
@@ -320,17 +320,16 @@ public class TlsClientImpl
         {
             if (clientCredentials == null)
             {
-                DtlsControlImpl dtlsControl = getDtlsControl();
+                CertificateInfo certificateInfo
+                    = getDtlsControl().getCertificateInfo();
 
-                /*
-                 * FIXME The signature and hash algorithms should be retrieved
-                 * from the certificate.
-                 */
+                // FIXME The signature and hash algorithms should be retrieved
+                // from the certificate.
                 clientCredentials
                     = new DefaultTlsSignerCredentials(
                             context,
-                            dtlsControl.getCertificate(),
-                            dtlsControl.getKeyPair().getPrivate(),
+                            certificateInfo.getCertificate(),
+                            certificateInfo.getKeyPair().getPrivate(),
                             new SignatureAndHashAlgorithm(
                                     HashAlgorithm.sha1,
                                     SignatureAlgorithm.rsa));

--- a/src/org/jitsi/impl/neomedia/transform/dtls/TlsClientImpl.java
+++ b/src/org/jitsi/impl/neomedia/transform/dtls/TlsClientImpl.java
@@ -127,8 +127,8 @@ public class TlsClientImpl
     {
         Hashtable clientExtensions = super.getClientExtensions();
 
-        if (!getDtlsControl().isSrtpDisabled() &&
-            TlsSRTPUtils.getUseSRTPExtension(clientExtensions) == null)
+        if (!isSrtpDisabled()
+                && TlsSRTPUtils.getUseSRTPExtension(clientExtensions) == null)
         {
             if (clientExtensions == null)
                 clientExtensions = new Hashtable();
@@ -188,6 +188,11 @@ public class TlsClientImpl
         return ProtocolVersion.DTLSv10;
     }
 
+    private Properties getProperties()
+    {
+        return packetTransformer.getProperties();
+    }
+
     /**
      * {@inheritDoc}
      *
@@ -201,6 +206,18 @@ public class TlsClientImpl
     {
         // TODO Auto-generated method stub
         super.init(context);
+    }
+
+    /**
+     * Determines whether this {@code TlsClientImpl} is to operate in pure DTLS
+     * mode without SRTP extensions or in DTLS/SRTP mode.
+     *
+     * @return {@code true} for pure DTLS without SRTP extensions or
+     * {@code false} for DTLS/SRTP
+     */
+    private boolean isSrtpDisabled()
+    {
+        return getProperties().isSrtpDisabled();
     }
 
     /**
@@ -231,7 +248,7 @@ public class TlsClientImpl
     public void processServerExtensions(Hashtable serverExtensions)
         throws IOException
     {
-        if (getDtlsControl().isSrtpDisabled())
+        if (isSrtpDisabled())
         {
             super.processServerExtensions(serverExtensions);
             return;

--- a/src/org/jitsi/impl/neomedia/transform/dtls/TlsServerImpl.java
+++ b/src/org/jitsi/impl/neomedia/transform/dtls/TlsServerImpl.java
@@ -197,13 +197,14 @@ public class TlsServerImpl
     {
         if (rsaEncryptionCredentials == null)
         {
-            DtlsControlImpl dtlsControl = getDtlsControl();
+            CertificateInfo certificateInfo
+                = getDtlsControl().getCertificateInfo();
 
             rsaEncryptionCredentials
                 = new DefaultTlsEncryptionCredentials(
                         context,
-                        dtlsControl.getCertificate(),
-                        dtlsControl.getKeyPair().getPrivate());
+                        certificateInfo.getCertificate(),
+                        certificateInfo.getKeyPair().getPrivate());
         }
         return rsaEncryptionCredentials;
     }
@@ -222,17 +223,16 @@ public class TlsServerImpl
     {
         if (rsaSignerCredentials == null)
         {
-            DtlsControlImpl dtlsControl = getDtlsControl();
+            CertificateInfo certificateInfo
+                = getDtlsControl().getCertificateInfo();
 
-            /*
-             * FIXME The signature and hash algorithms should be retrieved from
-             * the certificate.
-             */
+            // FIXME The signature and hash algorithms should be retrieved from
+            // the certificate.
             rsaSignerCredentials
                 = new DefaultTlsSignerCredentials(
                         context,
-                        dtlsControl.getCertificate(),
-                        dtlsControl.getKeyPair().getPrivate(),
+                        certificateInfo.getCertificate(),
+                        certificateInfo.getKeyPair().getPrivate(),
                         new SignatureAndHashAlgorithm(
                                 HashAlgorithm.sha1,
                                 SignatureAlgorithm.rsa));

--- a/src/org/jitsi/impl/neomedia/transform/dtls/TlsServerImpl.java
+++ b/src/org/jitsi/impl/neomedia/transform/dtls/TlsServerImpl.java
@@ -183,6 +183,11 @@ public class TlsServerImpl
         return ProtocolVersion.DTLSv10;
     }
 
+    private Properties getProperties()
+    {
+        return packetTransformer.getProperties();
+    }
+
     /**
      * {@inheritDoc}
      *
@@ -253,7 +258,7 @@ public class TlsServerImpl
     {
         Hashtable serverExtensions = getServerExtensionsOverride();
 
-        if (getDtlsControl().isSrtpDisabled())
+        if (isSrtpDisabled())
         {
             return serverExtensions;
         }
@@ -284,12 +289,10 @@ public class TlsServerImpl
             }
             else
             {
-                /*
-                 * Upon receipt of a "use_srtp" extension containing a
-                 * "srtp_mki" field, the server MUST include a matching
-                 * "srtp_mki" value in its "use_srtp" extension to indicate that
-                 * it will make use of the MKI.
-                 */
+                // Upon receipt of a "use_srtp" extension containing a
+                // "srtp_mki" field, the server MUST include a matching
+                // "srtp_mki" value in its "use_srtp" extension to indicate that
+                // it will make use of the MKI.
                 TlsSRTPUtils.addUseSRTPExtension(
                         serverExtensions,
                         new UseSRTPData(
@@ -314,35 +317,34 @@ public class TlsServerImpl
     private Hashtable getServerExtensionsOverride()
         throws IOException
     {
-        if (this.encryptThenMACOffered && allowEncryptThenMAC())
+        if (encryptThenMACOffered && allowEncryptThenMAC())
         {
-            /*
-             * draft-ietf-tls-encrypt-then-mac-03 3. If a server receives an
-             * encrypt-then-MAC request extension from a client and then selects
-             * a stream or AEAD cipher suite, it MUST NOT send an
-             * encrypt-then-MAC response extension back to the client.
-             */
-            if (TlsUtils.isBlockCipherSuite(this.selectedCipherSuite))
+            // draft-ietf-tls-encrypt-then-mac-03 3. If a server receives an
+            // encrypt-then-MAC request extension from a client and then selects
+            // a stream or AEAD cipher suite, it MUST NOT send an
+            // encrypt-then-MAC response extension back to the client.
+            if (TlsUtils.isBlockCipherSuite(selectedCipherSuite))
             {
                 TlsExtensionsUtils.addEncryptThenMACExtension(
-                    checkServerExtensions());
+                        checkServerExtensions());
             }
         }
 
-        if (this.maxFragmentLengthOffered >= 0
-            && MaxFragmentLength.isValid(maxFragmentLengthOffered))
+        if (maxFragmentLengthOffered >= 0
+                && MaxFragmentLength.isValid(maxFragmentLengthOffered))
         {
             TlsExtensionsUtils.addMaxFragmentLengthExtension(
-                checkServerExtensions(), this.maxFragmentLengthOffered);
+                    checkServerExtensions(),
+                    maxFragmentLengthOffered);
         }
 
-        if (this.truncatedHMacOffered && allowTruncatedHMac())
+        if (truncatedHMacOffered && allowTruncatedHMac())
         {
             TlsExtensionsUtils.addTruncatedHMacExtension(
-                checkServerExtensions());
+                    checkServerExtensions());
         }
 
-        if (TlsECCUtils.isECCCipherSuite(this.selectedCipherSuite))
+        if (TlsECCUtils.isECCCipherSuite(selectedCipherSuite))
         {
             /*
              * RFC 4492 5.2. A server that selects an ECC cipher suite in
@@ -351,13 +353,17 @@ public class TlsServerImpl
              * its ServerHello message, enumerating the point formats it can
              * parse.
              */
-            this.serverECPointFormats = new short[]{
-                ECPointFormat.uncompressed,
-                ECPointFormat.ansiX962_compressed_prime,
-                ECPointFormat.ansiX962_compressed_char2, };
+            serverECPointFormats
+                = new short[]
+                {
+                    ECPointFormat.uncompressed,
+                    ECPointFormat.ansiX962_compressed_prime,
+                    ECPointFormat.ansiX962_compressed_char2,
+                };
 
             TlsECCUtils.addSupportedPointFormatsExtension(
-                checkServerExtensions(), serverECPointFormats);
+                    checkServerExtensions(),
+                    serverECPointFormats);
         }
 
         return serverExtensions;
@@ -376,6 +382,18 @@ public class TlsServerImpl
     {
         // TODO Auto-generated method stub
         super.init(context);
+    }
+
+    /**
+     * Determines whether this {@code TlsServerImpl} is to operate in pure DTLS
+     * mode without SRTP extensions or in DTLS/SRTP mode.
+     *
+     * @return {@code true} for pure DTLS without SRTP extensions or
+     * {@code false} for DTLS/SRTP
+     */
+    private boolean isSrtpDisabled()
+    {
+        return getProperties().isSrtpDisabled();
     }
 
     /**
@@ -429,7 +447,7 @@ public class TlsServerImpl
     public void processClientExtensions(Hashtable clientExtensions)
         throws IOException
     {
-        if (getDtlsControl().isSrtpDisabled())
+        if (isSrtpDisabled())
         {
             super.processClientExtensions(clientExtensions);
             return;
@@ -454,10 +472,8 @@ public class TlsServerImpl
                 = DtlsControlImpl.chooseSRTPProtectionProfile(
                         useSRTPData.getProtectionProfiles());
 
-            /*
-             * If there is no shared profile and that is not acceptable, the
-             * server SHOULD return an appropriate DTLS alert.
-             */
+            // If there is no shared profile and that is not acceptable, the
+            // server SHOULD return an appropriate DTLS alert.
             if (chosenProtectionProfile == 0)
             {
                 String msg = "No chosen SRTP protection profile!";
@@ -468,7 +484,9 @@ public class TlsServerImpl
                 throw tfa;
             }
             else
+            {
                 super.processClientExtensions(clientExtensions);
+            }
         }
     }
 }

--- a/src/org/jitsi/impl/neomedia/transform/zrtp/ZrtpControlImpl.java
+++ b/src/org/jitsi/impl/neomedia/transform/zrtp/ZrtpControlImpl.java
@@ -65,12 +65,12 @@ public class ZrtpControlImpl
     }
 
     /**
-     * Cleans up the current zrtp control and its engine.
+     * {@inheritDoc}
      */
     @Override
-    public void cleanup(Object user)
+    public void doCleanup()
     {
-        super.cleanup(user);
+        super.doCleanup();
 
         zrtpConnector = null;
     }
@@ -257,9 +257,9 @@ public class ZrtpControlImpl
     }
 
     /**
-     * Returns false, ZRTP exchanges is keys over the media path.
+     * Returns {@code false}, ZRTP exchanges its keys over the media path.
      *
-     * @return false
+     * @return {@code false}
      */
     public boolean requiresSecureSignalingTransport()
     {

--- a/src/org/jitsi/service/neomedia/SrtpControl.java
+++ b/src/org/jitsi/service/neomedia/SrtpControl.java
@@ -48,7 +48,10 @@ public interface SrtpControl
 
     /**
      * Cleans up this <tt>SrtpControl</tt> and its <tt>TransformEngine</tt>.
-     * @param user the instance which requests the clean up.
+     *
+     * @param user the {@Object} which requests the clean-up and is supposedly
+     * currently using this {@code SrtpControl} (i.e. has already used
+     * {@link #registerUser(Object)}).
      */
     public void cleanup(Object user);
 
@@ -133,7 +136,9 @@ public interface SrtpControl
     /**
      * Registers <tt>user</tt> as an instance which is currently using this
      * <tt>SrtpControl</tt>.
-     * @param user
+     *
+     * @param user the {@code Object} which is currently using this
+     * {@code SrtpControl}
      */
     public void registerUser(Object user);
 }


### PR DESCRIPTION
The following modifications were applied while trying to remove a 1 second hard minimum on connectivity establishment between Videobridge and Chrome/WebRTC. Related modifications in jitsi-videobridge (i.e. which will be introduced in a branch there with the same name) (will) depend on these.

Of separate interest is commit 32c3e34 which fixes a long-standing issue of breaking DTLS flights into multiple UDP packets. The fix is desirable in the context of optimizing the connectivity establishment i.e. this PR.