### PR TITLE
Fixes a NullPointerException. (Reported by Damyan Minkov.)

### DIFF
--- a/src/org/jitsi/impl/neomedia/transform/dtls/Properties.java
+++ b/src/org/jitsi/impl/neomedia/transform/dtls/Properties.java
@@ -129,11 +129,15 @@ class Properties
      */
     public void put(String name, Object value)
     {
-        Object oldValue = properties.put(name, value);
-        boolean equals
-            = (oldValue == null) ? (value == null) : oldValue.equals(value);
+        // XXX ConcurrentHashMap does't allow null values and we want to allow
+        // them. (It doesn't allow null keys either and we don't want to allow
+        // them.)
+        Object oldValue
+            = (value == null)
+                ? properties.remove(name)
+                : properties.put(name, value);
 
-        if (!equals)
+        if (!Objects.equals(oldValue, value))
             firePropertyChange(name, oldValue, value);
     }
 }


### PR DESCRIPTION
21:31:50 JVB 2016-03-28 21:31:50.687 WARNING: [51] org.jitsi.videobridge.Conference.warn() Failed to close an IceUdpTransportManager of conference c8c2854fc6074e59!
21:31:50 java.lang.NullPointerException
21:31:50   at java.util.concurrent.ConcurrentHashMap.putVal(ConcurrentHashMap.java:1011)
21:31:50   at java.util.concurrent.ConcurrentHashMap.put(ConcurrentHashMap.java:1006)
21:31:50   at org.jitsi.impl.neomedia.transform.dtls.Properties.put(Properties.java:132)
21:31:50   at org.jitsi.impl.neomedia.transform.dtls.DtlsControlImpl.start(DtlsControlImpl.java:767)
21:31:50   at org.jitsi.videobridge.IceUdpTransportManager.close(IceUdpTransportManager.java:626)
21:31:50   at org.jitsi.videobridge.Conference.closeTransportManager(Conference.java:307)
21:31:50   at org.jitsi.videobridge.TransportManager.close(TransportManager.java:161)
21:31:50   at org.jitsi.videobridge.IceUdpTransportManager.close(IceUdpTransportManager.java:674)
21:31:50   at org.jitsi.videobridge.Channel.expire(Channel.java:366)
21:31:50   at org.jitsi.videobridge.RtpChannel.expire(RtpChannel.java:1968)
21:31:50   at org.jitsi.videobridge.Content.expire(Content.java:409)
21:31:50   at org.jitsi.videobridge.Conference.expire(Conference.java:615)
21:31:50   at org.jitsi.videobridge.health.Health.check(Health.java:155)
21:31:50   at org.jitsi.videobridge.Videobridge.handleHealthCheckIQ(Videobridge.java:1059)
21:31:50   at org.jitsi.videobridge.xmpp.ComponentImpl.handleIQRequest(ComponentImpl.java:402)
21:31:50   at org.jitsi.videobridge.xmpp.ComponentImpl.handleIQ(ComponentImpl.java:315)
21:31:50   at org.jitsi.videobridge.xmpp.ComponentImpl.handleIQ(ComponentImpl.java:267)
21:31:50   at org.jitsi.videobridge.xmpp.ComponentImpl.handleIQGet(ComponentImpl.java:366)
21:31:50   at org.xmpp.component.AbstractComponent.processIQRequest(AbstractComponent.java:511)
21:31:50   at org.xmpp.component.AbstractComponent.processIQ(AbstractComponent.java:289)
21:31:50   at org.xmpp.component.AbstractComponent.processQueuedPacket(AbstractComponent.java:239)
21:31:50   at org.xmpp.component.AbstractComponent.access$100(AbstractComponent.java:81)
21:31:50   at org.xmpp.component.AbstractComponent$PacketProcessor.run(AbstractComponent.java:1051)
21:31:50   at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
21:31:50   at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
21:31:50   at java.lang.Thread.run(Thread.java:745)
