### PR TITLE
Attempts to fix frequent short freezes.

### DIFF
--- a/src/org/jitsi/impl/neomedia/transform/rewriting/SsrcRewriter.java
+++ b/src/org/jitsi/impl/neomedia/transform/rewriting/SsrcRewriter.java
@@ -234,11 +234,8 @@ class SsrcRewriter
 
                 long newValue = p.getTimestamp();
 
-                if (newValue != oldValue)
-                {
-                    _lastSrcTimestamp = oldValue;
-                    _lastDstTimestamp = newValue;
-                }
+                _lastSrcTimestamp = oldValue;
+                _lastDstTimestamp = newValue;
             }
         }
     }


### PR DESCRIPTION
Suppose we have a frame being transmitted in 10 packets with timestamp
X. Our RTP timestamp rewriting is supposed to rewrite X -> Y. We have
observed that, under certain circumstances, our RTP timestamp rewriting
can start by rewriting X -> Y for the first few packets, and then X -> Z
for the rest of the packets. The circumstances under which this problem
manifests is when we receive an update for the remote clock -through RTCP-.