### PR TITLE
Remove reference to NIOBlockCipher in CryptoBenchmark

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,11 +83,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <excludes>
-            <exclude>org/jitsi/impl/neomedia/transform/srtp/CryptoBenchmark.java</exclude>
-          </excludes>
-        </configuration>
       </plugin>
       <plugin>
          <groupId>org.apache.felix</groupId>

--- a/src/org/jitsi/impl/neomedia/transform/srtp/CryptoBenchmark.java
+++ b/src/org/jitsi/impl/neomedia/transform/srtp/CryptoBenchmark.java
@@ -34,14 +34,11 @@ public class CryptoBenchmark
         throws Exception
     {
         boolean benchmarkJavaxCryptoCipher = false;
-        boolean benchmarkNIOBlockCipher = false;
 
         for (String arg : args)
         {
             if ("-javax-crypto-cipher".equalsIgnoreCase(arg))
                 benchmarkJavaxCryptoCipher = true;
-            else if ("-nio-block-cipher".equalsIgnoreCase(arg))
-                benchmarkNIOBlockCipher = true;
         }
 
         Provider sunPKCS11
@@ -160,10 +157,6 @@ public class CryptoBenchmark
             time0 = 0;
             for (BlockCipher blockCipher : ciphers)
             {
-                NIOBlockCipher nioBlockCipher
-                    = (blockCipher instanceof NIOBlockCipher)
-                        ? (NIOBlockCipher) blockCipher
-                        : null;
                 Cipher cipher;
                 Class<?> clazz;
 
@@ -185,26 +178,7 @@ public class CryptoBenchmark
                 long startTime, endTime;
                 int offEnd = in.length - blockSize;
 
-                if (nioBlockCipher != null && benchmarkNIOBlockCipher)
-                {
-                    inNIO.clear();
-                    outNIO.clear();
-
-                    startTime = System.nanoTime();
-                    for (int j = 0; j < jEnd; ++j)
-                    {
-                        for (int off = 0; off < offEnd;)
-                        {
-                            nioBlockCipher.processBlock(inNIO, off, outNIO, 0);
-                            off += blockSize;
-                        }
-//                        nioBlockCipher.reset();
-                    }
-                    endTime = System.nanoTime();
-
-                    outNIO.get(out);
-                }
-                else if (cipher != null && benchmarkJavaxCryptoCipher)
+                if (cipher != null && benchmarkJavaxCryptoCipher)
                 {
                     startTime = System.nanoTime();
                     for (int j = 0; j < jEnd; ++j)


### PR DESCRIPTION
NIOBlockCipher as been removed in PR #97
commit 18c951646db8d748f17d6aaeb7feec37439266f9

This was missed because CryptoBenchmark.java was excluded
in maven compilation, so don't exclude it

This fixes #132 (Broken Ant build)

Signed-off-by: Etienne CHAMPETIER <champetier.etienne@gmail.com>