### PR TITLE
Configurable DTLS certificate generation parameters.

### DIFF
--- a/src/org/jitsi/impl/neomedia/transform/dtls/DtlsControlImpl.java
+++ b/src/org/jitsi/impl/neomedia/transform/dtls/DtlsControlImpl.java
@@ -148,32 +148,6 @@ public class DtlsControlImpl
     public static final long DEFAULT_CERT_CACHE_EXPIRE_TIME = ONE_DAY;
 
     /**
-     * The name of the property to specify DTLS certificate validity time.
-     */
-    public static final String CERT_VALIDITY_TIME_PNAME =
-        "org.jitsi.impl.neomedia.transform.dtls.CERT_VALIDITY_TIME";
-
-
-    /**
-     * The certificate validity time to use, in milliseconds.
-     * The default value is {@code DEFAULT_CERT_VALIDITY_TIME} but may be
-     * overridden by the {@code ConfigurationService} and/or {@code System}
-     * property {@code CERT_VALIDITY_TIME_PNAME}.
-     * Determines the x.509 certificate Validity end date by adding this
-     * many milliseconds to the time of certificate generation. Note that this
-     * value must be at least the value of the {@code CERT_CACHE_EXPIRE_TIME}
-     * or else the server would not generate a valid certificate for a period.
-     */
-    public static final long CERT_VALIDITY_TIME;
-
-    /**
-     * The default certificate validity time, when config properties
-     * are not found.
-     */
-    public static final long DEFAULT_CERT_VALIDITY_TIME
-        = 6 * ONE_DAY;
-
-    /**
      * The public exponent to always use for RSA key generation.
      */
     public static final BigInteger RSA_KEY_PUBLIC_EXPONENT
@@ -237,15 +211,9 @@ public class DtlsControlImpl
 
         CERT_CACHE_EXPIRE_TIME
             = ConfigUtils.getLong(
-            LibJitsi.getConfigurationService(),
-                CERT_CACHE_EXPIRE_TIME_PNAME,
+                LibJitsi.getConfigurationService(),
+                    CERT_CACHE_EXPIRE_TIME_PNAME,
                     DEFAULT_CERT_CACHE_EXPIRE_TIME);
-
-        CERT_VALIDITY_TIME
-            = ConfigUtils.getLong(
-                    LibJitsi.getConfigurationService(),
-                    CERT_VALIDITY_TIME_PNAME,
-                    DEFAULT_CERT_VALIDITY_TIME);
 
         // HASH_FUNCTION_UPGRADES
         HASH_FUNCTION_UPGRADES.put(
@@ -522,7 +490,7 @@ public class DtlsControlImpl
         {
             long now = System.currentTimeMillis();
             Date notBefore = new Date(now - ONE_DAY);
-            Date notAfter = new Date(now + CERT_VALIDITY_TIME);
+            Date notAfter = new Date(now + ONE_DAY * 6 + CERT_CACHE_EXPIRE_TIME);
             X509v3CertificateBuilder builder
                 = new X509v3CertificateBuilder(
                         /* issuer */ subject,

--- a/src/org/jitsi/util/ConfigUtils.java
+++ b/src/org/jitsi/util/ConfigUtils.java
@@ -158,6 +158,52 @@ public class ConfigUtils
     }
 
     /**
+     * Gets the value as an {@code long} of a property from either a specific
+     * {@code ConfigurationService} or {@code System}.
+     *
+     * @param cfg the {@code ConfigurationService} to get the value from or
+     * {@code null} if the property is to be retrieved from {@code System}
+     * @param property the name of the property to get
+     * @param defaultValue the value to be returned if {@code property} is not
+     * associated with a value
+     * @return the value as an {@code long} of {@code property} retrieved from
+     * either {@code cfg} or {@code System}
+     */
+    public static long getLong(
+            ConfigurationService cfg,
+            String property,
+            long defaultValue)
+    {
+        long i;
+
+        if (cfg == null)
+        {
+            String s = System.getProperty(property);
+
+            if (s == null || s.length() == 0)
+            {
+                i = defaultValue;
+            }
+            else
+            {
+                try
+                {
+                    i = Long.parseLong(s);
+                }
+                catch (NumberFormatException nfe)
+                {
+                    i = defaultValue;
+                }
+            }
+        }
+        else
+        {
+            i = cfg.getLong(property, defaultValue);
+        }
+        return i;
+    }
+
+    /**
      * Gets the value as a {@code String} of a property from either a specific
      * {@code ConfigurationService} or {@code System}.
      *


### PR DESCRIPTION
This pull request is a replacement of https://github.com/jitsi/libjitsi/pull/67 which is now obsolete.

Here is a sample of property settings made available and being set:
org.jitsi.impl.neomedia.transform.dtls.RSA_KEY_SIZE_CERTAINTY=80
org.jitsi.impl.neomedia.transform.dtls.RSA_KEY_SIZE=2048
org.jitsi.impl.neomedia.transform.dtls.CERT_CACHE_EXPIRE_TIME=60000
<s>org.jitsi.impl.neomedia.transform.dtls.CERT_VALIDITY_TIME=43200000</s>

The jitsi-meet server administrator can set the number of key bits (...RSA_KEY_SIZE), set the certificate cache expire time (...CERT_CACHE_EXPIRE_TIME=0 for the "old" way should mean new certificate on every connection), and how long the certificate is valid for after the time of generation (...CERT_VALIDITY_TIME is above set to 12 hours). Times are in milliseconds.

Defaults remain the same as in master branch.

@ibauersachs and @champtar and @lyubomir please give your feedback on what can be improved in this pull request.

I have tested the above values using a properties file only and verified via wireshark to my server. I have not yet tried cache expiry of 0 yet, though I am pretty confident that will work too.

Thank you for considering this one, and you should already have a CLA on file.

One more note: had to add getLong to ConfigUtils in order to call it. That's why it's in here.