### PR TITLE
Closes the retranmission requester.

### DIFF
--- a/src/org/jitsi/impl/neomedia/MediaStreamImpl.java
+++ b/src/org/jitsi/impl/neomedia/MediaStreamImpl.java
@@ -705,6 +705,11 @@ public class MediaStreamImpl
             cachingTransformer = null;
         }
 
+        if (retransmissionRequester != null)
+        {
+            retransmissionRequester.close();
+        }
+
         if (transformEngineChain != null)
         {
             PacketTransformer t = transformEngineChain.getRTPTransformer();


### PR DESCRIPTION
If the transform engine chain was never initialized, the retransmission
requester will not be closed as part of the chain. Close it
separately.