### PR TITLE
Timestamp fixes.

### DIFF
--- a/src/org/jitsi/impl/neomedia/MediaStreamImpl.java
+++ b/src/org/jitsi/impl/neomedia/MediaStreamImpl.java
@@ -1046,15 +1046,15 @@ public class MediaStreamImpl
             engineChain.add(retransmissionRequester);
         }
 
+        if (cachingTransformer != null)
+        {
+            engineChain.add(cachingTransformer);
+        }
+
         absSendTimeEngine = createAbsSendTimeEngine();
         if (absSendTimeEngine != null)
         {
             engineChain.add(absSendTimeEngine);
-        }
-
-        if (cachingTransformer != null)
-        {
-            engineChain.add(cachingTransformer);
         }
 
         // Debug

--- a/src/org/jitsi/impl/neomedia/RawPacket.java
+++ b/src/org/jitsi/impl/neomedia/RawPacket.java
@@ -1379,4 +1379,30 @@ public class RawPacket
     {
         writeShort(getHeaderLength(), (short) sequenceNumber);
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toString()
+    {
+        // Note: this will not print meaningful values unless the packet is an
+        // RTP packet.
+        StringBuilder sb
+            = new StringBuilder("RawPacket[off=").append(offset)
+            .append(", len=").append(length)
+            .append(", PT=").append(getPayloadType())
+            .append(", SSRC=").append(getSSRCAsLong())
+            .append(", seq=").append(getSequenceNumber())
+            .append(", M=").append(isPacketMarked())
+            .append(", X=").append(getExtensionBit())
+            .append(", TS=").append(getTimestamp())
+            .append(", hdrLen=").append(getHeaderLength())
+            .append(", payloadLen=").append(getPayloadLength())
+            .append(", paddingLen=").append(getPaddingSize())
+            .append(", extLen=").append(getExtensionLength())
+            .append(']');
+
+        return sb.toString();
+    }
 }

--- a/src/org/jitsi/impl/neomedia/transform/RetransmissionRequesterImpl.java
+++ b/src/org/jitsi/impl/neomedia/transform/RetransmissionRequesterImpl.java
@@ -60,22 +60,6 @@ public class RetransmissionRequesterImpl
         = Logger.getLogger(RetransmissionRequesterImpl.class);
 
     /**
-     * Returns the difference between two RTP sequence numbers (modulo 2^16).
-     * @return the difference between two RTP sequence numbers (modulo 2^16).
-     */
-    private static int diff(int a, int b)
-    {
-        int diff = a - b;
-
-        if (diff < -(1<<15))
-            diff += 1<<16;
-        else if (diff > 1<<15)
-            diff -= 1<<16;
-
-        return diff;
-    }
-
-    /**
      * Maps an SSRC to the <tt>Requester</tt> instance corresponding to it.
      * TODO: purge these somehow (RTCP BYE? Timeout?)
      */
@@ -413,7 +397,7 @@ public class RetransmissionRequesterImpl
                 return;
             }
 
-            int diff = diff(seq, lastReceivedSeq);
+            int diff = RTPUtils.sequenceNumberDiff(seq, lastReceivedSeq);
             if (diff <= 0)
             {
                 // An older packet, possibly already requested.

--- a/src/org/jitsi/impl/neomedia/transform/rewriting/ExtendedSequenceNumberInterval.java
+++ b/src/org/jitsi/impl/neomedia/transform/rewriting/ExtendedSequenceNumberInterval.java
@@ -171,6 +171,21 @@ class ExtendedSequenceNumberInterval
         // Sequence number
         int seqnum = pkt.getSequenceNumber();
         int extendedSeqnum = ssrcRewriter.extendOriginalSequenceNumber(seqnum);
+        if (extendedSeqnum < extendedMinOrig)
+        {
+            // This is expected to happen if we just switched simulcast streams,
+            // and we received retransmissions for packets before the switch.
+            // Drop these, because they are not supposed to be sent to the
+            // received (their sequence number has been used by packets from
+            // the previous stream).
+            if (DEBUG)
+            {
+                logger.debug(
+                    "Dropping a packet outside this interval: " + pkt);
+            }
+            return null;
+        }
+
         int rewriteSeqnum = rewriteExtendedSequenceNumber(extendedSeqnum);
 
         pkt.setSequenceNumber(rewriteSeqnum);

--- a/src/org/jitsi/impl/neomedia/transform/rewriting/ExtendedSequenceNumberInterval.java
+++ b/src/org/jitsi/impl/neomedia/transform/rewriting/ExtendedSequenceNumberInterval.java
@@ -110,50 +110,21 @@ class ExtendedSequenceNumberInterval
     long lastSeen;
 
     /**
-     * Holds the max RTP timestamp that we've sent (to the endpoint)
-     * in this interval.
-     */
-    public long maxTimestamp;
-
-    /**
-     * Defines the minimum timestamp for this extended sequence number interval
-     * (inclusive).
-     *
-     * When there's a stream switch, we request a keyframe for the stream we
-     * want to switch into (this is done elsewhere). The {@link SsrcRewriter}
-     * rewrites the timestamps of the "mixed" streams so that they all have the
-     * same timestamp offset. The problem still remains tho, frames can be
-     * sampled at different times, so we might end up with a key frame that is
-     * one sampling cycle behind what we were already streaming. We hack around
-     * this by implementing "RTP timestamp uplifting".
-     *
-     * RTP timestamp uplifting happens here, in this class. If, after timestamp
-     * rewriting, we get a packet with a timestamp smaller than minTimestamp,
-     * we overwrite it with minTimestamp. We don't expect to receive more than
-     * one frame that needs to be uplifted.
-     */
-    private final long minTimestamp;
-
-    /**
      * Ctor.
      *
      * @param ssrcRewriter
      * @param extendedBaseOrig
      * @param extendedBaseTarget
-     * @param minTimestamp
      */
     public ExtendedSequenceNumberInterval(
             SsrcRewriter ssrcRewriter,
-            int extendedBaseOrig, int extendedBaseTarget,
-            long minTimestamp)
+            int extendedBaseOrig, int extendedBaseTarget)
     {
         this.ssrcRewriter = ssrcRewriter;
         this.extendedBaseTarget = extendedBaseTarget;
 
         this.extendedMinOrig = extendedBaseOrig;
         this.extendedMaxOrig = extendedBaseOrig;
-
-        this.minTimestamp = minTimestamp;
     }
 
     /**
@@ -249,83 +220,7 @@ class ExtendedSequenceNumberInterval
         if (rtx && !rewriteRTX(pkt))
             return null;
 
-        // timestamp
-        //
-        // XXX Since we may be rewriting the RTP timestamp and, consequently, we
-        // may be remembering timestamp-related state, it sounds better to do
-        // these after FEC and RTX have not discarded pkt.
-        rewriteTimestamp(pkt);
-
         return pkt;
-    }
-
-    /**
-     * Rewrites the RTP timestamp of a specific RTP packet.
-     *
-     * @param p the {@code RawPacket} which represents the RTP packet to rewrite
-     * the RTP timestamp of
-     */
-    private void rewriteTimestamp(RawPacket p)
-    {
-        // There is nothing specific to ExtendedSequenceNumberInterval in the
-        // rewriting of the RTP timestamps at the time of this writing. Forward
-        // to the owner/parent i.e. SsrcRewriter.
-        ssrcRewriter.rewriteTimestamp(p);
-
-        // Uplift the timestamp of a frame if we've already sent a larger
-        // timestamp to the remote endpoint.
-        //
-        // XXX(gp): The uplifting should not take place if the
-        // timestamps have advanced "a lot" (i.e. > 3000).
-
-        long timestamp = p.getTimestamp();
-        long delta = timestamp - minTimestamp;
-
-        if (delta < 0) /* minTimestamp is inclusive */
-        {
-            if (DEBUG)
-            {
-                logger.debug(
-                    "Uplifting RTP timestamp " + timestamp
-                        + " with SEQNUM " + p.getSequenceNumber()
-                        + " from SSRC " + p.getSSRCAsLong()
-                        + " because of delta " + delta + " to "
-                        + minTimestamp);
-            }
-
-            if (delta < -3000)
-            {
-                // Bail-out. This is not supposed to happen because it means
-                // that more than one frame has to be uplifted, which means that
-                // we might be mis-rewriting the timestamps (since we're
-                // switching on neighboring frames and neighboring frames are
-                // sampled at similar instances).
-
-                if (WARN)
-                {
-
-                    logger.warn(
-                        "BAILING OUT to uplift RTP timestamp " + timestamp
-                            + " with SEQNUM " + p.getSequenceNumber()
-                            + " from SSRC " + p.getSSRCAsLong()
-                            + " because of " + delta + " (delta > 3000) to "
-                            + minTimestamp);
-                }
-
-                return;
-            }
-
-            p.setTimestamp(minTimestamp);
-        }
-        else
-        {
-            // FIXME If the delta is >>> 3000 it could mean problems as well.
-        }
-
-        if (maxTimestamp < timestamp)
-        {
-            maxTimestamp = timestamp;
-        }
     }
 
     /**

--- a/src/org/jitsi/impl/neomedia/transform/rewriting/SsrcGroupRewriter.java
+++ b/src/org/jitsi/impl/neomedia/transform/rewriting/SsrcGroupRewriter.java
@@ -476,6 +476,15 @@ class SsrcGroupRewriter
      */
     public void maybeUpliftTimestamp(RawPacket p)
     {
+        // XXX Why do we need this? : When there's a stream switch, we request a
+        // keyframe for the stream we want to switch into (this is done
+        // elsewhere). The {@link SsrcRewriter} rewrites the timestamps of the
+        // "mixed" streams so that they all have the same timestamp offset. The
+        // problem still remains tho, frames can be sampled at different times,
+        // so we might end up with a key frame that is one sampling cycle behind
+        // what we were already streaming. We hack around this by implementing
+        // "RTP timestamp uplifting".
+
         // XXX(gp): The uplifting should not take place if the
         // timestamps have advanced "a lot" (i.e. > 3000 or 3000/90 = 33ms).
 

--- a/src/org/jitsi/impl/neomedia/transform/rewriting/SsrcGroupRewriter.java
+++ b/src/org/jitsi/impl/neomedia/transform/rewriting/SsrcGroupRewriter.java
@@ -479,16 +479,6 @@ class SsrcGroupRewriter
     }
 
     /**
-     * Gets the {@code MediaStreamImpl} associated with this instance.
-     *
-     * @return the {@code MediaStreamImpl} associated with this instance
-     */
-    public MediaStreamImpl getMediaStreamImpl()
-    {
-        return ssrcRewritingEngine.getMediaStreamImpl();
-    }
-
-    /**
      * Gets the SSRC of the RTP stream into whose RTP timestamp other RTP
      * streams are rewritten.
      *

--- a/src/org/jitsi/impl/neomedia/transform/rewriting/SsrcGroupRewriter.java
+++ b/src/org/jitsi/impl/neomedia/transform/rewriting/SsrcGroupRewriter.java
@@ -160,7 +160,7 @@ class SsrcGroupRewriter
         // packet MUST NOT send a BYE packet when they leave the group.
         if (getActiveRewriter() != null)
         {
-            MediaStream mediaStream = getMediaStream();
+            MediaStream mediaStream = ssrcRewritingEngine.getMediaStream();
 
             if (mediaStream != null)
             {
@@ -466,16 +466,6 @@ class SsrcGroupRewriter
             // 16 bits).
             return targetExtendedSeqnum & 0x0000ffff;
         }
-    }
-
-    /**
-     * Gets the {@code MediaStream} associated with this instance.
-     *
-     * @return the {@code MediaStream} associated with this instance
-     */
-    public MediaStream getMediaStream()
-    {
-        return ssrcRewritingEngine.getMediaStream();
     }
 
     /**

--- a/src/org/jitsi/impl/neomedia/transform/rewriting/SsrcRewriter.java
+++ b/src/org/jitsi/impl/neomedia/transform/rewriting/SsrcRewriter.java
@@ -458,7 +458,7 @@ class SsrcRewriter
 
     /**
      *
-     * @param ssOrigSeqnum
+     * @param origSeqnum
      * @return
      */
     int extendOriginalSequenceNumber(int origSeqnum)
@@ -487,15 +487,5 @@ class SsrcRewriter
     public MediaStream getMediaStream()
     {
         return ssrcGroupRewriter.getMediaStream();
-    }
-
-    /**
-     * Gets the {@code MediaStreamImpl} associated with this instance.
-     *
-     * @return the {@code MediaStreamImpl} associated with this instance
-     */
-    public MediaStreamImpl getMediaStreamImpl()
-    {
-        return ssrcGroupRewriter.getMediaStreamImpl();
     }
 }

--- a/src/org/jitsi/impl/neomedia/transform/rewriting/SsrcRewriter.java
+++ b/src/org/jitsi/impl/neomedia/transform/rewriting/SsrcRewriter.java
@@ -52,6 +52,11 @@ class SsrcRewriter
     private static final boolean TRACE;
 
     /**
+     * The maximum number of entries in the timestamp history.
+     */
+    private static final int TS_HISTORY_MAX_ENTRIES = 100;
+
+    /**
      * The origin SSRC that this <tt>SsrcRewriter</tt> rewrites. The
      * target SSRC is managed by the parent <tt>SsrcGroupRewriter</tt>.
      */
@@ -78,22 +83,23 @@ class SsrcRewriter
             = new TreeMap<>();
 
     /**
+     * The MRU timestamp history.
+     */
+    private final Map<Long, Long> tsHistory = new LinkedHashMap<Long, Long>() {
+
+        @Override
+        protected boolean removeEldestEntry(Map.Entry eldest) {
+            return size() > TS_HISTORY_MAX_ENTRIES;
+        }
+    };
+
+    /**
      * This is the current sequence number interval for this origin
      * SSRC. We can't have it in the intervals navigable map because
      * its max isn't determined yet. If this is null, then it means that
      * this original SSRC is paused (invariant).
      */
     private ExtendedSequenceNumberInterval currentExtendedSequenceNumberInterval;
-
-    private static final int MAX_ENTRIES = 100;
-
-    private final Map<Long, Long> tsHistory = new LinkedHashMap<Long, Long>() {
-
-        @Override
-        protected boolean removeEldestEntry(Map.Entry eldest) {
-            return size() > MAX_ENTRIES;
-        }
-    };
 
     /**
      * Static init.

--- a/src/org/jitsi/impl/neomedia/transform/rewriting/SsrcRewriter.java
+++ b/src/org/jitsi/impl/neomedia/transform/rewriting/SsrcRewriter.java
@@ -252,6 +252,8 @@ class SsrcRewriter
                     // wallclock of timestampSsrc.
                     rewriteTimestamp(p, sourceSsrc, timestampSsrc);
                 }
+
+                ssrcGroupRewriter.maybeUpliftTimestamp(p);
             }
 
             long newValue = p.getTimestamp();
@@ -308,7 +310,6 @@ class SsrcRewriter
         }
 
         rewriteTimestamp(p, clocks[0], clocks[1]);
-        ssrcGroupRewriter.maybeUpliftTimestamp(p);
     }
 
     /**

--- a/src/org/jitsi/impl/neomedia/transform/rewriting/SsrcRewritingEngine.java
+++ b/src/org/jitsi/impl/neomedia/transform/rewriting/SsrcRewritingEngine.java
@@ -114,11 +114,6 @@ public class SsrcRewritingEngine implements TransformEngine
     private final MediaStream mediaStream;
 
     /**
-     * The view of {@link #mediaStream} as a {@code MediaStreamImpl} instance.
-     */
-    private final MediaStreamImpl _mediaStreamImpl;
-
-    /**
      * Generates <tt>RawPacket</tt>s from <tt>RTCPCompoundPacket</tt>s.
      */
     private final RTCPGenerator generator = new RTCPGenerator();
@@ -221,11 +216,6 @@ public class SsrcRewritingEngine implements TransformEngine
     public SsrcRewritingEngine(MediaStream mediaStream)
     {
         this.mediaStream = mediaStream;
-
-        _mediaStreamImpl
-            = (mediaStream instanceof MediaStreamImpl)
-                ? (MediaStreamImpl) mediaStream
-                : null;
 
         logger.debug("Created a new SSRC rewriting engine.");
     }
@@ -496,18 +486,6 @@ public class SsrcRewritingEngine implements TransformEngine
     public MediaStream getMediaStream()
     {
         return mediaStream;
-    }
-
-    /**
-     * Gets the {@code MediaStreamImpl} which has initialized this instance and
-     * is its owner.
-     *
-     * @return the {@code MediaStreamImpl} which has initialized this instance
-     * and is its owner
-     */
-    public MediaStreamImpl getMediaStreamImpl()
-    {
-        return _mediaStreamImpl;
     }
 
     /**

--- a/src/org/jitsi/util/RTPUtils.java
+++ b/src/org/jitsi/util/RTPUtils.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright @ 2015 Atlassian Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.util;
+
+/**
+ * RTP-related static utility methods.
+ * @author Boris Grozev
+ */
+public class RTPUtils
+{
+    /**
+     * Returns the difference between two RTP sequence numbers (modulo 2^16).
+     * @return the difference between two RTP sequence numbers (modulo 2^16).
+     */
+    public static int sequenceNumberDiff(int a, int b)
+    {
+        int diff = a - b;
+
+        if (diff < -(1<<15))
+            diff += 1<<16;
+        else if (diff > 1<<15)
+            diff -= 1<<16;
+
+        return diff;
+    }
+}


### PR DESCRIPTION
This PR contains some fixes for RTP timestamp rewriting which will help reduce the number of freezes during a simulcast enabled conference.