### PR TITLE
Compare Long using equals and not ==

### DIFF
--- a/src/org/jitsi/impl/neomedia/DominantSpeakerIdentification.java
+++ b/src/org/jitsi/impl/neomedia/DominantSpeakerIdentification.java
@@ -648,7 +648,7 @@ public class DominantSpeakerIdentification
                 }
             }
         }
-        if ((newDominantSSRC != null) && (newDominantSSRC != dominantSSRC))
+        if ((newDominantSSRC != null) && !newDominantSSRC.equals(dominantSSRC))
         {
             oldDominantSpeakerValue = dominantSSRC;
             dominantSSRC = newDominantSSRC;
@@ -659,7 +659,8 @@ public class DominantSpeakerIdentification
 
         // Now that we are outside the synchronized block, fire events, if any,
         // to any registered listeners.
-        if (oldDominantSpeakerValue != newDominantSpeakerValue)
+        if ((newDominantSpeakerValue != null) &&
+            !newDominantSpeakerValue.equals(oldDominantSpeakerValue))
         {
             firePropertyChange(
                     DOMINANT_SPEAKER_PROPERTY_NAME,


### PR DESCRIPTION
Two different Long objects A and B can have the same value
giving true for A.equals(B) but false for A == B

Found using FindBugs
http://findbugs.sourceforge.net/bugDescriptions.html#RC_REF_COMPARISON

Signed-off-by: Etienne CHAMPETIER <champetier.etienne@gmail.com>