### PR TITLE
Ensure localSourceID is positive

### DIFF
--- a/src/org/jitsi/impl/neomedia/MediaStreamImpl.java
+++ b/src/org/jitsi/impl/neomedia/MediaStreamImpl.java
@@ -173,8 +173,7 @@ public class MediaStreamImpl
      * {@link this.rtpManager}, given that it offers this information with its
      * getLocalSSRC() method? TAG(cat4-local-ssrc-hurricane)
      */
-    private long localSourceID
-        = Math.abs(new Random().nextLong()) % Integer.MAX_VALUE;
+    private long localSourceID = (new Random().nextInt()) & 0x000000007FFFFFFFL;
 
     /**
      * The MediaStreamStatsImpl object used to compute the statistics about


### PR DESCRIPTION
Math.abs(Long.MIN_VALUE) == Long.MIN_VALUE which is negative
https://docs.oracle.com/javase/7/docs/api/java/lang/Math.html#abs%28long%29

Before this commit
 0 <= localSourceID < Integer.MAX_VALUE
 or localSourceID == (Long.MIN_VALUE % Integer.MAX_VALUE) == -2
After
 0 <= localSourceID <= Integer.MAX_VALUE

This was found using FindBugs
http://findbugs.sourceforge.net/bugDescriptions.html#RV_ABSOLUTE_VALUE_OF_RANDOM_INT

Signed-off-by: Etienne CHAMPETIER <champetier.etienne@gmail.com>