### PR TITLE
Fix possible byte conversion bug

### DIFF
--- a/src/org/jitsi/impl/neomedia/codec/REDBlockIterator.java
+++ b/src/org/jitsi/impl/neomedia/codec/REDBlockIterator.java
@@ -246,7 +246,7 @@ public class REDBlockIterator
             //|F|   block PT  |  timestamp offset         |   block length    |
             //+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
             blockLen = (buffer[offNextBlockHeader + 2] & 0x03) << 8
-                | (buffer[offNextBlockHeader + 3]);
+                | (buffer[offNextBlockHeader + 3] & 0xFF);
             offNextBlockHeader += 4; // next RED header
             offNextBlockPayload += blockLen;
         }

--- a/src/org/jitsi/impl/neomedia/recording/SynchronizerImpl.java
+++ b/src/org/jitsi/impl/neomedia/recording/SynchronizerImpl.java
@@ -429,7 +429,7 @@ public class SynchronizerImpl
         if (v != 2)
             return false;
 
-        int lengthInWords = (buf[off + 2] << 8) + buf[off + 3];
+        int lengthInWords = (buf[off + 2] & 0xFF) << 8 | (buf[off + 3] & 0xFF);
         int lengthInBytes = (lengthInWords + 1) * 4;
         if (len < lengthInBytes)
             return false;

--- a/src/org/jitsi/impl/neomedia/transform/AbsSendTimeEngine.java
+++ b/src/org/jitsi/impl/neomedia/transform/AbsSendTimeEngine.java
@@ -134,8 +134,8 @@ public class AbsSendTimeEngine
             return false;
         }
 
-        int lengthInWords
-                = buf[extensionOffset++] << 8 | buf[extensionOffset++];
+        int lengthInWords = (buf[extensionOffset++] & 0xFF) << 8
+            | (buf[extensionOffset++] & 0xFF);
 
         // Length in bytes of the header extensions
         int lengthInBytes = 4 * (1 + lengthInWords);

--- a/src/org/jitsi/impl/neomedia/transform/REDTransformEngine.java
+++ b/src/org/jitsi/impl/neomedia/transform/REDTransformEngine.java
@@ -216,7 +216,7 @@ public class REDTransformEngine
         //write non-primary packets, keep pkts[0] for the primary
         for (int i = 1; i < pktCount; i++)
         {
-            int blockLen = (buf[idx + 2] & 0x03) << 8 | (buf[idx + 3]);
+            int blockLen = (buf[idx + 2] & 0x03) << 8 | (buf[idx + 3] & 0xFF);
 
             // XXX: we might need to optimize
             byte[] newBuf = new byte[hdrLen + blockLen];

--- a/src/org/jitsi/impl/neomedia/transform/rtcp/CompoundPacketEngine.java
+++ b/src/org/jitsi/impl/neomedia/transform/rtcp/CompoundPacketEngine.java
@@ -54,7 +54,7 @@ public class CompoundPacketEngine
         if (RTCPHeader.VERSION != v)
             return -1;
 
-        int lengthInWords = (buf[off + 2] << 8) + buf[off + 3];
+        int lengthInWords = ((buf[off + 2] & 0xFF) << 8) | (buf[off + 3] & 0xFF);
         int lengthInBytes = (lengthInWords + 1) * 4;
         if (len < lengthInBytes)
             return -1;

--- a/src/org/jitsi/sctp4j/SctpNotification.java
+++ b/src/org/jitsi/sctp4j/SctpNotification.java
@@ -125,7 +125,7 @@ public class SctpNotification
 
     public static SctpNotification parse(byte[] data)
     {
-        int type = data[0] | (data[1] << 8);
+        int type = (data[1] & 0xFF) << 8 | (data[0] & 0xFF);
         switch (type)
         {
             case SCTP_ASSOC_CHANGE:


### PR DESCRIPTION
bytes in java are signed, and when you convert them to a
bigger type, like int, java perform what we call sign extension
and FF become FFFFFFFF before you shift (<<),
giving you unexpected result (compared to C)

Found using FindBugs
http://findbugs.sourceforge.net/bugDescriptions.html#BIT_ADD_OF_SIGNED_BYTE
http://findbugs.sourceforge.net/bugDescriptions.html#BIT_IOR_OF_SIGNED_BYTE

Signed-off-by: Etienne CHAMPETIER <champetier.etienne@gmail.com>