### PR TITLE
Use byte instead of int for the constant time comparison

### DIFF
--- a/src/org/jitsi/impl/neomedia/transform/srtp/SRTCPCryptoContext.java
+++ b/src/org/jitsi/impl/neomedia/transform/srtp/SRTCPCryptoContext.java
@@ -335,7 +335,7 @@ public class SRTCPCryptoContext
             authenticatePacketHMAC(pkt, indexEflag);
 
             // compare authentication tags using constant time comparison
-            int nonEqual = 0;
+            byte nonEqual = 0;
             for (int i = 0; i < tagLength; i++)
             {
                 nonEqual |= (tempStore[i] ^ tagStore[i]);

--- a/src/org/jitsi/impl/neomedia/transform/srtp/SRTPCryptoContext.java
+++ b/src/org/jitsi/impl/neomedia/transform/srtp/SRTPCryptoContext.java
@@ -252,7 +252,7 @@ public class SRTPCryptoContext
             authenticatePacketHMAC(pkt, guessedROC);
 
             // compare authentication tags using constant time comparison
-            int nonEqual = 0;
+            byte nonEqual = 0;
             for (int i = 0; i < tagLength; i++)
             {
                 nonEqual |= (tempStore[i] ^ tagStore[i]);


### PR DESCRIPTION
no need to expend byte into int each round

Signed-off-by: Etienne CHAMPETIER <champetier.etienne@gmail.com>