### PR TITLE
Restore AES192/256 SRTP functionality

### DIFF
--- a/src/org/jitsi/impl/neomedia/transform/sdes/SDesTransformEngine.java
+++ b/src/org/jitsi/impl/neomedia/transform/sdes/SDesTransformEngine.java
@@ -171,6 +171,8 @@ public class SDesTransformEngine
         switch (cs.getEncryptionAlgorithm())
         {
             case SrtpCryptoSuite.ENCRYPTION_AES128_CM:
+            case SrtpCryptoSuite.ENCRYPTION_AES192_CM:
+            case SrtpCryptoSuite.ENCRYPTION_AES256_CM:
                 return SRTPPolicy.AESCM_ENCRYPTION;
             case SrtpCryptoSuite.ENCRYPTION_AES128_F8:
                 return SRTPPolicy.AESF8_ENCRYPTION;

--- a/src/org/jitsi/impl/neomedia/transform/srtp/BaseSRTPCryptoContext.java
+++ b/src/org/jitsi/impl/neomedia/transform/srtp/BaseSRTPCryptoContext.java
@@ -200,17 +200,19 @@ class BaseSRTPCryptoContext
             break;
 
         case SRTPPolicy.AESF8_ENCRYPTION:
-            cipherF8 = new SRTPCipherF8(AES.createBlockCipher());
+            cipherF8 = new SRTPCipherF8(AES.createBlockCipher(encKeyLength));
             //$FALL-THROUGH$
 
         case SRTPPolicy.AESCM_ENCRYPTION:
-            if (OpenSSLWrapperLoader.isLoaded())
+            // use OpenSSL if available and AES128 is in use
+            if (OpenSSLWrapperLoader.isLoaded() && encKeyLength == 16)
             {
                 cipherCtr = new SRTPCipherCTROpenSSL();
             }
             else
             {
-                cipherCtr = new SRTPCipherCTRJava(AES.createBlockCipher());
+                cipherCtr = new SRTPCipherCTRJava(
+                    AES.createBlockCipher(encKeyLength));
             }
             encKey = new byte[encKeyLength];
             saltKey = new byte[saltKeyLength];

--- a/src/org/jitsi/impl/neomedia/transform/srtp/BlockCipherFactory.java
+++ b/src/org/jitsi/impl/neomedia/transform/srtp/BlockCipherFactory.java
@@ -27,11 +27,12 @@ public interface BlockCipherFactory
 {
     /**
      * Initializes a new <tt>BlockCipher</tt> instance.
+     * @param keySize AES key size (16, 24, 32 bytes)
      *
      * @return a new <tt>BlockCipher</tt> instance
      * @throws Exception if anything goes wrong while initializing a new
      * <tt>BlockCipher</tt> instance
      */
-    public BlockCipher createBlockCipher()
+    public BlockCipher createBlockCipher(int keySize)
         throws Exception;
 }

--- a/src/org/jitsi/impl/neomedia/transform/srtp/SRTPCipherCTRJava.java
+++ b/src/org/jitsi/impl/neomedia/transform/srtp/SRTPCipherCTRJava.java
@@ -40,8 +40,8 @@ public class SRTPCipherCTRJava extends SRTPCipherCTR
      */
     public void init(byte[] key)
     {
-        if (key.length != BLKLEN)
-            throw new IllegalArgumentException("key.length != BLKLEN");
+        if (key.length != 16 && key.length != 24 && key.length != 32)
+            throw new IllegalArgumentException("Not an AES key length");
 
         cipher.init(true, new KeyParameter(key));
     }

--- a/src/org/jitsi/impl/neomedia/transform/srtp/SecurityProviderBlockCipherFactory.java
+++ b/src/org/jitsi/impl/neomedia/transform/srtp/SecurityProviderBlockCipherFactory.java
@@ -88,11 +88,13 @@ public class SecurityProviderBlockCipherFactory
      * {@inheritDoc}
      */
     @Override
-    public BlockCipher createBlockCipher()
+    public BlockCipher createBlockCipher(int keySize)
         throws Exception
     {
         return
             new BlockCipherAdapter(
-                    Cipher.getInstance(transformation, provider));
+                    Cipher.getInstance(transformation.replaceFirst(
+                        "<size>",
+                        new Integer(keySize * 8).toString()), provider));
     }
 }


### PR DESCRIPTION
The introduction of the various cipher factories ignored AES192/256, which can be used by ZRTP. SDES was partially broken too, but had the option in the UI for a while.