### PR TITLE
Use colons instead of dashes in a=imageattr lines.

### DIFF
--- a/src/org/jitsi/impl/neomedia/MediaUtils.java
+++ b/src/org/jitsi/impl/neomedia/MediaUtils.java
@@ -610,7 +610,7 @@ public class MediaUtils
     /**
      * Creates value of an imgattr.
      *
-     * http://tools.ietf.org/html/draft-ietf-mmusic-image-attributes-04
+     * https://tools.ietf.org/html/rfc6236
      *
      * @param sendSize maximum size peer can send
      * @param maxRecvSize maximum size peer can display
@@ -632,10 +632,10 @@ public class MediaUtils
             img.append(",y=");
             img.append((int)sendSize.getHeight());
             img.append("]");*/
-            /* send [x=[min-max],y=[min-max]] */
-            img.append("send [x=[0-");
+            /* send [x=[min:max],y=[min:max]] */
+            img.append("send [x=[1:");
             img.append((int)sendSize.getWidth());
-            img.append("],y=[0-");
+            img.append("],y=[1:");
             img.append((int)sendSize.getHeight());
             img.append("]]");
             /*
@@ -644,11 +644,11 @@ public class MediaUtils
                 // range
                 img.append(" send [x=[");
                 img.append((int)minSendSize.getWidth());
-                img.append("-");
+                img.append(":");
                 img.append((int)maxSendSize.getWidth());
                 img.append("],y=[");
                 img.append((int)minSendSize.getHeight());
-                img.append("-");
+                img.append(":");
                 img.append((int)maxSendSize.getHeight());
                 img.append("]]");
             }
@@ -665,10 +665,10 @@ public class MediaUtils
         {
             // basically we can receive any size up to our screen display size
 
-            /* recv [x=[min-max],y=[min-max]] */
-            img.append(" recv [x=[0-");
+            /* recv [x=[min:max],y=[min:max]] */
+            img.append(" recv [x=[1:");
             img.append((int)maxRecvSize.getWidth());
-            img.append("],y=[0-");
+            img.append("],y=[1:");
             img.append((int)maxRecvSize.getHeight());
             img.append("]]");
         }

--- a/src/org/jitsi/impl/neomedia/VideoMediaStreamImpl.java
+++ b/src/org/jitsi/impl/neomedia/VideoMediaStreamImpl.java
@@ -96,9 +96,9 @@ public class VideoMediaStreamImpl
         Pattern pSendSingle = Pattern.compile("send \\[x=[0-9]+,y=[0-9]+\\]");
         Pattern pRecvSingle = Pattern.compile("recv \\[x=[0-9]+,y=[0-9]+\\]");
         Pattern pSendRange = Pattern.compile(
-                "send \\[x=\\[[0-9]+:[0-9]+\\],y=\\[[0-9]+:[0-9]+\\]\\]");
+                "send \\[x=\\[[0-9]+(-|:)[0-9]+\\],y=\\[[0-9]+(-|:)[0-9]+\\]\\]");
         Pattern pRecvRange = Pattern.compile(
-                "recv \\[x=\\[[0-9]+:[0-9]+\\],y=\\[[0-9]+:[0-9]+\\]\\]");
+                "recv \\[x=\\[[0-9]+(-|:)[0-9]+\\],y=\\[[0-9]+(-|:)[0-9]+\\]\\]");
         Pattern pNumeric = Pattern.compile("[0-9]+");
         Matcher mSingle = null;
         Matcher mRange = null;

--- a/src/org/jitsi/impl/neomedia/VideoMediaStreamImpl.java
+++ b/src/org/jitsi/impl/neomedia/VideoMediaStreamImpl.java
@@ -96,9 +96,9 @@ public class VideoMediaStreamImpl
         Pattern pSendSingle = Pattern.compile("send \\[x=[0-9]+,y=[0-9]+\\]");
         Pattern pRecvSingle = Pattern.compile("recv \\[x=[0-9]+,y=[0-9]+\\]");
         Pattern pSendRange = Pattern.compile(
-                "send \\[x=\\[[0-9]+-[0-9]+\\],y=\\[[0-9]+-[0-9]+\\]\\]");
+                "send \\[x=\\[[0-9]+:[0-9]+\\],y=\\[[0-9]+:[0-9]+\\]\\]");
         Pattern pRecvRange = Pattern.compile(
-                "recv \\[x=\\[[0-9]+-[0-9]+\\],y=\\[[0-9]+-[0-9]+\\]\\]");
+                "recv \\[x=\\[[0-9]+:[0-9]+\\],y=\\[[0-9]+:[0-9]+\\]\\]");
         Pattern pNumeric = Pattern.compile("[0-9]+");
         Matcher mSingle = null;
         Matcher mRange = null;
@@ -107,7 +107,7 @@ public class VideoMediaStreamImpl
         /* resolution (width and height) can be on four forms
          *
          * - single value [x=1920,y=1200]
-         * - range of values [x=[800-1024],y=[600-768]]
+         * - range of values [x=[800:1024],y=[600:768]]
          * - fixed range of values [x=[800,1024],y=[600,768]]
          * - range of values with step [x=[800:32:1024],y=[600:32:768]]
          *
@@ -134,7 +134,7 @@ public class VideoMediaStreamImpl
         }
         else if(mRange.find()) /* try with range */
         {
-            /* have two value for width and two for height (min-max) */
+            /* have two value for width and two for height (min:max) */
             int val[]  = new int[4];
             int i = 0;
             token = imgattr.substring(mRange.start(), mRange.end());
@@ -169,7 +169,7 @@ public class VideoMediaStreamImpl
         }
         else if(mRange.find()) /* try with range */
         {
-            /* have two value for width and two for height (min-max) */
+            /* have two value for width and two for height (min:max) */
             int val[]  = new int[4];
             int i = 0;
             token = imgattr.substring(mRange.start(), mRange.end());


### PR DESCRIPTION
Also, starts ranges with 1 instead of 0.

Links to RFC 6236 instead of draft-ietf-mmusic-image-attributes-04.

This fixes the Jitsi bug reported here:
http://lists.jitsi.org/pipermail/users/2016-June/011253.html