### PR TITLE
RTP timestamp uplifting fixes

### DIFF
--- a/src/org/jitsi/impl/neomedia/transform/rewriting/SsrcGroupRewriter.java
+++ b/src/org/jitsi/impl/neomedia/transform/rewriting/SsrcGroupRewriter.java
@@ -527,6 +527,7 @@ class SsrcGroupRewriter
             }
 
             p.setTimestamp(minTimestamp);
+            timestamp = minTimestamp;
         }
         else
         {

--- a/src/org/jitsi/impl/neomedia/transform/rewriting/SsrcRewritingEngine.java
+++ b/src/org/jitsi/impl/neomedia/transform/rewriting/SsrcRewritingEngine.java
@@ -530,7 +530,7 @@ public class SsrcRewritingEngine implements TransformEngine
                 {
                     logger.trace("Not rewriting ssrc=" + pkt.getSSRCAsLong()
                         + ", seq=" + pkt.getSequenceNumber()
-                        + "because the SSRC rewriting engine is not "
+                        + " because the SSRC rewriting engine is not "
                         + "initialized.");
                 }
 
@@ -552,7 +552,7 @@ public class SsrcRewritingEngine implements TransformEngine
                 {
                     logger.warn("Not rewriting ssrc=" + pkt.getSSRCAsLong()
                         + ", seq=" + pkt.getSequenceNumber()
-                        + "because we could not find an SSRC group rewriter.");
+                        + " because we could not find an SSRC group rewriter.");
                 }
                 return pkt;
             }


### PR DESCRIPTION
Makes sure we update the minTimestamp value when we perform RTP
timestamp uplifting. Failure in doing so may result in maxTimestamp
not being updated, breaking RTP timestamp uplifting.