### PR TITLE
Use a ConcurrentHashMap to store sockets.

### DIFF
--- a/src/org/jitsi/sctp4j/Sctp.java
+++ b/src/org/jitsi/sctp4j/Sctp.java
@@ -17,6 +17,7 @@ package org.jitsi.sctp4j;
 
 import java.io.*;
 import java.util.*;
+import java.util.concurrent.*;
 
 import org.jitsi.util.*;
 
@@ -55,7 +56,7 @@ public class Sctp
      * List of instantiated <tt>SctpSockets</tt> mapped by native pointer.
      */
     private static final Map<Long,SctpSocket> sockets
-        = new HashMap<Long,SctpSocket>();
+        = new ConcurrentHashMap<>();
 
     static
     {
@@ -306,7 +307,7 @@ public class Sctp
      * FIXME add offset and length buffer parameters.
      * @param ptr native socket pointer.
      * @param data the data to send.
-     * @param offset the position of the data inside the buffer
+     * @param off the position of the data inside the buffer
      * @param len data length.
      * @param ordered should we care about message order ?
      * @param sid SCTP stream identifier


### PR DESCRIPTION
Attempts to fix a failure to accept() an SCTP socket in
jitsi-videobridge. We observed the following log:
No SctpSocket found for ptr: 140437445429440