### PR TITLE
SSRC rewriting renames

### DIFF
--- a/src/org/jitsi/impl/neomedia/transform/rewriting/ExtendedSequenceNumberInterval.java
+++ b/src/org/jitsi/impl/neomedia/transform/rewriting/ExtendedSequenceNumberInterval.java
@@ -74,7 +74,7 @@ class ExtendedSequenceNumberInterval
     /**
      * The owner of this instance.
      */
-    public final SsrcRewriter ssrcRewriter;
+    public final RTPEncodingRewriter rtpEncodingRewriter;
 
     /**
      * Static init.
@@ -93,7 +93,7 @@ class ExtendedSequenceNumberInterval
         public boolean test(REDBlock redBlock)
         {
             Map<Integer, Byte> ssrc2fec = getSsrcRewritingEngine().ssrc2fec;
-            int sourceSSRC = ssrcRewriter.getSourceSSRC();
+            int sourceSSRC = rtpEncodingRewriter.getSourceSSRC();
             return redBlock != null
                 && ssrc2fec.get(sourceSSRC) == redBlock.getPayloadType();
         }
@@ -112,15 +112,15 @@ class ExtendedSequenceNumberInterval
     /**
      * Ctor.
      *
-     * @param ssrcRewriter
+     * @param rtpEncodingRewriter
      * @param extendedBaseOrig
      * @param extendedBaseTarget
      */
     public ExtendedSequenceNumberInterval(
-            SsrcRewriter ssrcRewriter,
+            RTPEncodingRewriter rtpEncodingRewriter,
             int extendedBaseOrig, int extendedBaseTarget)
     {
-        this.ssrcRewriter = ssrcRewriter;
+        this.rtpEncodingRewriter = rtpEncodingRewriter;
         this.extendedBaseTarget = extendedBaseTarget;
 
         this.extendedMinOrig = extendedBaseOrig;
@@ -170,7 +170,8 @@ class ExtendedSequenceNumberInterval
 
         // Sequence number
         int seqnum = pkt.getSequenceNumber();
-        int extendedSeqnum = ssrcRewriter.extendOriginalSequenceNumber(seqnum);
+        int extendedSeqnum
+            = rtpEncodingRewriter.extendOriginalSequenceNumber(seqnum);
         if (extendedSeqnum < extendedMinOrig)
         {
             // This is expected to happen if we just switched simulcast streams,
@@ -193,7 +194,7 @@ class ExtendedSequenceNumberInterval
         SsrcRewritingEngine ssrcRewritingEngine
             = ssrcGroupRewriter.ssrcRewritingEngine;
         Map<Integer, Integer> rtx2primary = ssrcRewritingEngine.rtx2primary;
-        int sourceSSRC = ssrcRewriter.getSourceSSRC();
+        int sourceSSRC = rtpEncodingRewriter.getSourceSSRC();
         Integer primarySSRC = rtx2primary.get(sourceSSRC);
 
         if (primarySSRC == null)
@@ -247,7 +248,7 @@ class ExtendedSequenceNumberInterval
     {
         // This is an RTX packet. Replace RTX OSN field or drop.
         SsrcRewritingEngine ssrcRewritingEngine = getSsrcRewritingEngine();
-        int sourceSSRC = ssrcRewriter.getSourceSSRC();
+        int sourceSSRC = rtpEncodingRewriter.getSourceSSRC();
         int ssrcOrig = ssrcRewritingEngine.rtx2primary.get(sourceSSRC);
         int snOrig = pkt.getOriginalSequenceNumber();
 
@@ -385,7 +386,7 @@ class ExtendedSequenceNumberInterval
      */
     public SsrcGroupRewriter getSsrcGroupRewriter()
     {
-        return ssrcRewriter.ssrcGroupRewriter;
+        return rtpEncodingRewriter.ssrcGroupRewriter;
     }
 
     /**

--- a/src/org/jitsi/impl/neomedia/transform/rewriting/ExtendedSequenceNumberInterval.java
+++ b/src/org/jitsi/impl/neomedia/transform/rewriting/ExtendedSequenceNumberInterval.java
@@ -163,8 +163,8 @@ class ExtendedSequenceNumberInterval
     public RawPacket rewriteRTP(RawPacket pkt)
     {
         // SSRC
-        SsrcGroupRewriter ssrcGroupRewriter = getSsrcGroupRewriter();
-        int ssrcTarget = ssrcGroupRewriter.getSSRCTarget();
+        MediaStreamTrackRewriter mstRewriter = getSsrcGroupRewriter();
+        int ssrcTarget = mstRewriter.getSSRCTarget();
 
         pkt.setSSRC(ssrcTarget);
 
@@ -192,7 +192,7 @@ class ExtendedSequenceNumberInterval
         pkt.setSequenceNumber(rewriteSeqnum);
 
         SsrcRewritingEngine ssrcRewritingEngine
-            = ssrcGroupRewriter.ssrcRewritingEngine;
+            = mstRewriter.ssrcRewritingEngine;
         Map<Integer, Integer> rtx2primary = ssrcRewritingEngine.rtx2primary;
         int sourceSSRC = rtpEncodingRewriter.getSourceSSRC();
         Integer primarySSRC = rtx2primary.get(sourceSSRC);
@@ -252,7 +252,7 @@ class ExtendedSequenceNumberInterval
         int ssrcOrig = ssrcRewritingEngine.rtx2primary.get(sourceSSRC);
         int snOrig = pkt.getOriginalSequenceNumber();
 
-        SsrcGroupRewriter rewriterPrimary
+        MediaStreamTrackRewriter rewriterPrimary
             = ssrcRewritingEngine.origin2rewriter.get(ssrcOrig);
         int sequenceNumber
             = rewriterPrimary.rewriteSequenceNumber(ssrcOrig, snOrig);
@@ -353,7 +353,7 @@ class ExtendedSequenceNumberInterval
         // +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
         int snBase = (buf[off + 2] & 0xff) << 8 | (buf[off + 3] & 0xff);
 
-        SsrcGroupRewriter rewriter
+        MediaStreamTrackRewriter rewriter
             = getSsrcRewritingEngine().origin2rewriter.get(sourceSSRC);
         int snRewritenBase
             = rewriter.rewriteSequenceNumber(sourceSSRC, snBase);
@@ -378,20 +378,20 @@ class ExtendedSequenceNumberInterval
     }
 
     /**
-     * Gets the {@code SsrcGroupRewriter} which has initialized this instance
+     * Gets the {@code MediaStreamTrackRewriter} which has initialized this instance
      * and is its owner.
      *
-     * @return the {@code SsrcGroupRewriter} which has initialized this instance
+     * @return the {@code MediaStreamTrackRewriter} which has initialized this instance
      * and is its owner
      */
-    public SsrcGroupRewriter getSsrcGroupRewriter()
+    public MediaStreamTrackRewriter getSsrcGroupRewriter()
     {
-        return rtpEncodingRewriter.ssrcGroupRewriter;
+        return rtpEncodingRewriter.mstRewriter;
     }
 
     /**
      * Gets the {@code SsrcRewritingEngine} associated with this instance i.e.
-     * which owns the {@code SsrcGroupRewriter} which in turn owns this
+     * which owns the {@code MediaStreamTrackRewriter} which in turn owns this
      * instance.
      *
      * @return the {@code SsrcRewritingEngine} associated with this instance

--- a/src/org/jitsi/impl/neomedia/transform/rewriting/MediaStreamTrackRewriter.java
+++ b/src/org/jitsi/impl/neomedia/transform/rewriting/MediaStreamTrackRewriter.java
@@ -32,33 +32,33 @@ import org.jitsi.util.*;
  * @author George Politis
  * @author Lyubomir Marinov
  */
-class SsrcGroupRewriter
+class MediaStreamTrackRewriter
 {
     /**
-     * The <tt>Logger</tt> used by the <tt>SsrcGroupRewriter</tt> class and
-     * its instances to print debug information.
+     * The <tt>Logger</tt> used by the <tt>MediaStreamTrackRewriter</tt> class
+     * and its instances to print debug information.
      */
     private static final Logger logger
-        = Logger.getLogger(SsrcGroupRewriter.class);
+        = Logger.getLogger(MediaStreamTrackRewriter.class);
 
     /**
      * The value of {@link Logger#isTraceEnabled()} from the time of the
-     * initialization of the class {@code SsrcGroupRewriter} cached for the
-     * purposes of performance.
+     * initialization of the class {@code MediaStreamTrackRewriter} cached for
+     * the purposes of performance.
      */
     private static final boolean TRACE;
 
     /**
      * The value of {@link Logger#isDebugEnabled()} from the time of the
-     * initialization of the class {@code SsrcGroupRewriter} cached for the
-     * purposes of performance.
+     * initialization of the class {@code MediaStreamTrackRewriter} cached for
+     * the purposes of performance.
      */
     private static final boolean DEBUG;
 
     /**
      * The value of {@link Logger#isWarnEnabled()} from the time of the
-     * initialization of the class {@code SsrcGroupRewriter} cached for the
-     * purposes of performance.
+     * initialization of the class {@code MediaStreamTrackRewriter} cached for
+     * the purposes of performance.
      */
     private static final boolean WARN;
 
@@ -130,9 +130,10 @@ class SsrcGroupRewriter
      * Ctor.
      *
      * @param ssrcRewritingEngine the owner of this instance.
-     * @param ssrcTarget the target SSRC for this <tt>SsrcGroupRewriter</tt>.
+     * @param ssrcTarget the target SSRC for this
+     * <tt>MediaStreamTrackRewriter</tt>.
      */
-    public SsrcGroupRewriter(
+    public MediaStreamTrackRewriter(
             SsrcRewritingEngine ssrcRewritingEngine,
             Integer ssrcTarget,
             int seqnumBase)

--- a/src/org/jitsi/impl/neomedia/transform/rewriting/RTPEncodingRewriter.java
+++ b/src/org/jitsi/impl/neomedia/transform/rewriting/RTPEncodingRewriter.java
@@ -19,7 +19,6 @@ import java.util.*;
 import net.sf.fmj.media.rtp.*;
 import org.jitsi.impl.neomedia.*;
 import org.jitsi.impl.neomedia.rtcp.*;
-import org.jitsi.service.neomedia.*;
 import org.jitsi.util.*;
 
 /**
@@ -29,25 +28,26 @@ import org.jitsi.util.*;
  * @author George Politis
  * @author Lyubomir Marinov
  */
-class SsrcRewriter
+class RTPEncodingRewriter
 {
     /**
      * The <tt>Logger</tt> used by the <tt>SsrcRewritingEngine</tt> class and
      * its instances to print debug information.
      */
-    private static final Logger logger = Logger.getLogger(SsrcRewriter.class);
+    private static final Logger logger
+        = Logger.getLogger(RTPEncodingRewriter.class);
 
     /**
      * The value of {@link Logger#isDebugEnabled()} from the time of the
-     * initialization of the class {@code SsrcRewriter} cached for the purposes
-     * of performance.
+     * initialization of the class {@code RTPEncodingRewriter} cached for the
+     * purposes of performance.
      */
     private static final boolean DEBUG;
 
     /**
      * The value of {@link Logger#isTraceEnabled()} from the time of the
-     * initialization of the class {@code SsrcRewriter} cached for the purposes
-     * of performance.
+     * initialization of the class {@code RTPEncodingRewriter} cached for the
+     * purposes of performance.
      */
     private static final boolean TRACE;
 
@@ -57,7 +57,7 @@ class SsrcRewriter
     private static final int TS_HISTORY_MAX_ENTRIES = 100;
 
     /**
-     * The origin SSRC that this <tt>SsrcRewriter</tt> rewrites. The
+     * The origin SSRC that this <tt>RTPEncodingRewriter</tt> rewrites. The
      * target SSRC is managed by the parent <tt>SsrcGroupRewriter</tt>.
      */
     private final int sourceSSRC;
@@ -116,7 +116,8 @@ class SsrcRewriter
      * @param ssrcGroupRewriter
      * @param sourceSSRC
      */
-    public SsrcRewriter(SsrcGroupRewriter ssrcGroupRewriter, int sourceSSRC)
+    public RTPEncodingRewriter(
+        SsrcGroupRewriter ssrcGroupRewriter, int sourceSSRC)
     {
         this.ssrcGroupRewriter = ssrcGroupRewriter;
         this.sourceSSRC = sourceSSRC;
@@ -133,7 +134,7 @@ class SsrcRewriter
     }
 
     /**
-     * Gets the source SSRC for this <tt>SsrcRewriter</tt>.
+     * Gets the source SSRC for this <tt>RTPEncodingRewriter</tt>.
      */
     public int getSourceSSRC()
     {

--- a/src/org/jitsi/impl/neomedia/transform/rewriting/SsrcGroupRewriter.java
+++ b/src/org/jitsi/impl/neomedia/transform/rewriting/SsrcGroupRewriter.java
@@ -63,10 +63,10 @@ class SsrcGroupRewriter
     private static final boolean WARN;
 
     /**
-     * A map of SSRCs to <tt>SsrcRewriter</tt>. Each SSRC that we rewrite in
-     * this group rewriter has its own rewriter.
+     * A map of SSRCs to <tt>RTPEncodingRewriter</tt>. Each SSRC that we rewrite
+     * in this group rewriter has its own rewriter.
      */
-    private final Map<Integer, SsrcRewriter> rewriters = new HashMap<>();
+    private final Map<Integer, RTPEncodingRewriter> rewriters = new HashMap<>();
 
     /**
      * The owner of this instance.
@@ -75,7 +75,7 @@ class SsrcGroupRewriter
 
     /**
      * The target SSRC that the rewritten RTP packets will have. This is
-     * shared between all the "child" <tt>SsrcRewriter</tt>s.
+     * shared between all the "child" <tt>RTPEncodingRewriter</tt>s.
      */
     private final int ssrcTarget;
 
@@ -104,11 +104,11 @@ class SsrcGroupRewriter
     public long maxTimestamp = -1;
 
     /**
-     * The current <tt>SsrcRewriter</tt> that we use to rewrite source
+     * The current <tt>RTPEncodingRewriter</tt> that we use to rewrite source
      * SSRCs. The active rewriter is determined by the RTP packets that
      * we get.
      */
-    private SsrcRewriter activeRewriter;
+    private RTPEncodingRewriter activeRewriter;
 
     /**
      * The SSRC of the RTP stream into whose RTP timestamp other RTP streams
@@ -220,11 +220,11 @@ class SsrcGroupRewriter
     }
 
     /**
-     * Gets the active <tt>SsrcRewriter</tt> of this instance.
+     * Gets the active <tt>RTPEncodingRewriter</tt> of this instance.
      *
-     * @return the active <tt>SsrcRewriter</tt> of this instance.
+     * @return the active <tt>RTPEncodingRewriter</tt> of this instance.
      */
-    public SsrcRewriter getActiveRewriter()
+    public RTPEncodingRewriter getActiveRewriter()
     {
         return activeRewriter;
     }
@@ -327,15 +327,15 @@ class SsrcGroupRewriter
                             + pkt.getSSRCAsLong() + " to "
                             + (ssrcTarget & 0xffffffffL));
             }
-            rewriters.put(sourceSSRC, new SsrcRewriter(this, sourceSSRC));
+            rewriters.put(sourceSSRC, new RTPEncodingRewriter(this, sourceSSRC));
         }
 
         if (activeRewriter != null
                 && activeRewriter.getSourceSSRC() != sourceSSRC)
         {
             // Got a packet with a different SSRC from the one that the current
-            // SsrcRewriter handles. Pause the current SsrcRewriter and switch
-            // to the correct one.
+            // RTPEncodingRewriter handles. Pause the current
+            // RTPEncodingRewriter and switch to the correct one.
             if (DEBUG)
             {
                 logger.debug(
@@ -434,7 +434,7 @@ class SsrcGroupRewriter
      */
     int rewriteSequenceNumber(int ssrcOrigin, int seqnum)
     {
-        SsrcRewriter rewriter = rewriters.get(ssrcOrigin);
+        RTPEncodingRewriter rewriter = rewriters.get(ssrcOrigin);
         if (rewriter == null)
         {
             logger.warn(
@@ -478,12 +478,12 @@ class SsrcGroupRewriter
     {
         // XXX Why do we need this? : When there's a stream switch, we request a
         // keyframe for the stream we want to switch into (this is done
-        // elsewhere). The {@link SsrcRewriter} rewrites the timestamps of the
-        // "mixed" streams so that they all have the same timestamp offset. The
-        // problem still remains tho, frames can be sampled at different times,
-        // so we might end up with a key frame that is one sampling cycle behind
-        // what we were already streaming. We hack around this by implementing
-        // "RTP timestamp uplifting".
+        // elsewhere). The {@link RTPEncodingRewriter} rewrites the timestamps
+        // of the "mixed" streams so that they all have the same timestamp
+        // offset. The problem still remains tho, frames can be sampled at
+        // different times, so we might end up with a key frame that is one
+        // sampling cycle behind what we were already streaming. We hack around
+        // this by implementing "RTP timestamp uplifting".
 
         // XXX(gp): The uplifting should not take place if the
         // timestamps have advanced "a lot" (i.e. > 3000 or 3000/90 = 33ms).

--- a/src/org/jitsi/impl/neomedia/transform/rewriting/SsrcRewritingEngine.java
+++ b/src/org/jitsi/impl/neomedia/transform/rewriting/SsrcRewritingEngine.java
@@ -460,14 +460,15 @@ public class SsrcRewritingEngine implements TransformEngine
             return INVALID_SSRC;
         }
 
-        SsrcRewriter activeRewriter = ssrcGroupRewriter.getActiveRewriter();
+        RTPEncodingRewriter activeRewriter
+            = ssrcGroupRewriter.getActiveRewriter();
 
         if (activeRewriter == null)
         {
             if (logger.isDebugEnabled())
             {
                 logger.debug(
-                        "Could not find an SsrcRewriter for SSRC: "
+                        "Could not find an RTPEncodingRewriter for SSRC: "
                             + (ssrc & 0xffffffffL));
             }
             return INVALID_SSRC;

--- a/src/org/jitsi/impl/neomedia/transform/rewriting/SsrcRewritingEngine.java
+++ b/src/org/jitsi/impl/neomedia/transform/rewriting/SsrcRewritingEngine.java
@@ -129,10 +129,11 @@ public class SsrcRewritingEngine implements TransformEngine
     private final SeqnumBaseKeeper seqnumBaseKeeper = new SeqnumBaseKeeper();
 
     /**
-     * A <tt>Map</tt> that maps source SSRCs to <tt>SsrcGroupRewriter</tt>s. It
-     * can be used to quickly find which <tt>SsrcGroupRewriter</tt> to use for
-     * a specific RTP packet based on its SSRC. Multiple SSRCs can be mapped to
-     * the same <tt>SsrcGroupRewriter</tt>, so this is not a 1-1 map.
+     * A <tt>Map</tt> that maps source SSRCs to
+     * <tt>MediaStreamTrackRewriter</tt>s. It can be used to quickly find which
+     * <tt>MediaStreamTrackRewriter</tt> to use for a specific RTP packet based
+     * on its SSRC. Multiple SSRCs can be mapped to the same
+     * <tt>MediaStreamTrackRewriter</tt>, so this is not a 1-1 map.
      * <p/>
      * One other thing to note is that this map holds both primary and RTX
      * origin SSRCs and will hold RED/FEC SSRCs in the future as well, when
@@ -144,18 +145,19 @@ public class SsrcRewritingEngine implements TransformEngine
      * be to use RWL or synchronized blocks. Not sure about the performance
      * diff, but locks for reading sound heavy.
      */
-    Map<Integer, SsrcGroupRewriter> origin2rewriter;
+    Map<Integer, MediaStreamTrackRewriter> origin2rewriter;
 
     /**
-     * A <tt>Map</tt> that maps target SSRCs to <tt>SsrcGroupRewriter</tt>s. It
-     * can be used to quickly find an <tt>SsrcGroupRewriter</tt> by its SSRC.
-     * Each target SSRC is mapped to a different <tt>SsrcGroupRewriter</tt>, so
-     * this is a 1-1 map. We're wrapping the <tt>SsrcGroupRewriter</tt> in a
+     * A <tt>Map</tt> that maps target SSRCs to
+     * <tt>MediaStreamTrackRewriter</tt>s. It can be used to quickly find an
+     * <tt>MediaStreamTrackRewriter</tt> by its SSRC. Each target SSRC is mapped
+     * to a different <tt>MediaStreamTrackRewriter</tt>, so this is a 1-1 map.
+     * We're wrapping the <tt>MediaStreamTrackRewriter</tt> in a
      * <tt>Tracked</tt> class so the engine instance can count how many source
      * SSRCs a target SSRC is rewriting. The purpose of this is to BYE target
      * SSRCs that no longer have source SSRCs.
      */
-    private Map<Integer, RefCount<SsrcGroupRewriter>> target2rewriter;
+    private Map<Integer, RefCount<MediaStreamTrackRewriter>> target2rewriter;
 
     /**
      * Maps RTX SSRCs to primary SSRCs.
@@ -302,11 +304,11 @@ public class SsrcRewritingEngine implements TransformEngine
         // BYE target SSRCs that no longer have source/original SSRCs.
         // TODO we need a way to garbage collect target SSRCs that should have
         // been unmapped.
-        for (Iterator<RefCount<SsrcGroupRewriter>> i
-                    = target2rewriter.values().iterator();
-                i.hasNext();)
+        for (Iterator<RefCount<MediaStreamTrackRewriter>> i
+             = target2rewriter.values().iterator();
+             i.hasNext();)
         {
-            RefCount<SsrcGroupRewriter> refCount = i.next();
+            RefCount<MediaStreamTrackRewriter> refCount = i.next();
 
             if (refCount.get() < 1)
             {
@@ -399,22 +401,24 @@ public class SsrcRewritingEngine implements TransformEngine
 
         if (ssrcTarget != null && ssrcTarget != UNMAP_SSRC)
         {
-            RefCount<SsrcGroupRewriter> refCount
+            RefCount<MediaStreamTrackRewriter> refCount
                 = target2rewriter.get(ssrcTarget);
 
             if (refCount == null)
             {
-                // Create an <tt>SsrcGroupRewriter</tt> for the target SSRC.
+                // Create an <tt>MediaStreamTrackRewriter</tt> for the target
+                // SSRC.
                 refCount = new RefCount<>(
                     seqnumBaseKeeper.createSsrcGroupRewriter(this, ssrcTarget));
                 target2rewriter.put(ssrcTarget, refCount);
             }
 
-            // Link the original SSRC to the appropriate SsrcGroupRewriter.
-            SsrcGroupRewriter oldSsrcGroupRewriter
+            // Link the original SSRC to the appropriate
+            // MediaStreamTrackRewriter.
+            MediaStreamTrackRewriter oldMSTRewriter
                 = origin2rewriter.put(ssrcOrig, refCount.getReferent());
 
-            if (oldSsrcGroupRewriter == null)
+            if (oldMSTRewriter == null)
             {
                 // We put one and nothing was removed, so we must increase.
                 refCount.increase();
@@ -427,13 +431,13 @@ public class SsrcRewritingEngine implements TransformEngine
         else
         {
             // Unmap the origin SSRC and the target SSRC.
-            SsrcGroupRewriter ssrcGroupRewriter
+            MediaStreamTrackRewriter mstRewriter
                 = origin2rewriter.remove(ssrcOrig);
 
-            if (ssrcGroupRewriter != null)
+            if (mstRewriter != null)
             {
-                RefCount<SsrcGroupRewriter> refCount
-                    = target2rewriter.get(ssrcGroupRewriter.getSSRCTarget());
+                RefCount<MediaStreamTrackRewriter> refCount
+                    = target2rewriter.get(mstRewriter.getSSRCTarget());
 
                 refCount.decrease();
             }
@@ -449,19 +453,19 @@ public class SsrcRewritingEngine implements TransformEngine
      */
     private long reverseRewriteSSRC(int ssrc)
     {
-        // If there is an SsrcGroupRewriter, rewrite the packet; otherwise,
-        // include it unaltered.
-        RefCount<SsrcGroupRewriter> refCount = target2rewriter.get(ssrc);
-        SsrcGroupRewriter ssrcGroupRewriter;
+        // If there is an MediaStreamTrackRewriter, rewrite the packet;
+        // otherwise, include it unaltered.
+        RefCount<MediaStreamTrackRewriter> refCount = target2rewriter.get(ssrc);
+        MediaStreamTrackRewriter mstRewriter;
 
         if (refCount == null
-                || (ssrcGroupRewriter = refCount.getReferent()) == null)
+                || (mstRewriter = refCount.getReferent()) == null)
         {
             return INVALID_SSRC;
         }
 
         RTPEncodingRewriter activeRewriter
-            = ssrcGroupRewriter.getActiveRewriter();
+            = mstRewriter.getActiveRewriter();
 
         if (activeRewriter == null)
         {
@@ -538,14 +542,14 @@ public class SsrcRewritingEngine implements TransformEngine
                 return pkt;
             }
 
-            // Use the SSRC of the RTP packet to find which SsrcGroupRewriter to
-            // use.
+            // Use the SSRC of the RTP packet to find which
+            // {@link MediaStreamTrackRewriter} to use.
             int ssrc = pkt.getSSRC();
-            SsrcGroupRewriter ssrcGroupRewriter = origin2rewriter.get(ssrc);
+            MediaStreamTrackRewriter mstRewriter = origin2rewriter.get(ssrc);
 
-            // If there is an SsrcGroupRewriter, rewrite the packet; otherwise,
-            // return it unaltered.
-            if (ssrcGroupRewriter == null)
+            // If there is an MediaStreamTrackRewriter, rewrite the packet;
+            // otherwise, return it unaltered.
+            if (mstRewriter == null)
             {
                 // We don't have a rewriter for this packet. Let's not freak
                 // out about it, it's most probably a DTLS packet.
@@ -559,7 +563,7 @@ public class SsrcRewritingEngine implements TransformEngine
             }
             else
             {
-                return ssrcGroupRewriter.rewriteRTP(pkt);
+                return mstRewriter.rewriteRTP(pkt);
             }
         }
     }
@@ -627,7 +631,7 @@ public class SsrcRewritingEngine implements TransformEngine
             for (RTCPPacket inPkt : inPkts)
             {
                 // Use the SSRC of the RTCP packet to find which
-                // <tt>SsrcGroupRewriter</tt> to use.
+                // <tt>MediaStreamTrackRewriter</tt> to use.
 
                 // XXX we could move the RawPacket methods into a utils
                 // class with static methods so that we don't have to create
@@ -668,7 +672,8 @@ public class SsrcRewritingEngine implements TransformEngine
                         {
                             // We only really care if it's NOT a REMB.
                             logger.debug(
-                                    "Could not find an SsrcGroupRewriter for"
+                                    "Could not find an" +
+                                        " MediaStreamTrackRewriter for"
                                         + " the RTCP packet: " + psfb);
                         }
                         else
@@ -694,8 +699,8 @@ public class SsrcRewritingEngine implements TransformEngine
                                 {
                                     logger.debug(
                                             "Could not find an"
-                                                + " SsrcGroupRewriter for the"
-                                                + " RTCP packet: " + psfb);
+                                                + " MediaStreamTrackRewriter " +
+                                                "for the RTCP packet: " + psfb);
                                 }
                                 else
                                 {
@@ -808,7 +813,7 @@ public class SsrcRewritingEngine implements TransformEngine
          * @param ssrcTarget
          * @return
          */
-        public synchronized SsrcGroupRewriter createSsrcGroupRewriter(
+        public synchronized MediaStreamTrackRewriter createSsrcGroupRewriter(
             SsrcRewritingEngine ssrcRewritingEngine, Integer ssrcTarget)
         {
             int seqnum;
@@ -823,13 +828,13 @@ public class SsrcRewritingEngine implements TransformEngine
 
             if (TRACE)
             {
-                logger.trace("Creating a new SsrcGroupRewriter (ssrc="
+                logger.trace("Creating a new MediaStreamTrackRewriter (ssrc="
                     + (ssrcTarget & 0xffffffffl)
                     + ", seqnum=" + seqnum + ").");
             }
 
-            return
-                new SsrcGroupRewriter(ssrcRewritingEngine, ssrcTarget, seqnum);
+            return new MediaStreamTrackRewriter(
+                ssrcRewritingEngine, ssrcTarget, seqnum);
         }
     }
 }


### PR DESCRIPTION
The SsrcRewriter doesn't rewrite SSRCs. It takes into account payload types, RTX SSRCs and future FEC SSRCs. Getting inspired by the ORTC standard, these things can be grouped in an "RTPEncoding".

Similarly, SsrcGroupRewriter is an extremely poor name for that class. What this class does is rewriting RTP encodings that belong to the same media stream track. So, why not name this class MediaStreamTrack.

This is a first small step towards re-organizing the libjitsi SSRC representation that will allow us to move stuff from the JVB back into the libjitsi, where they really belong.