### PR TITLE
Fix the array out of bound issue in keyframe detection

### DIFF
--- a/src/org/jitsi/impl/neomedia/codec/video/h264/DePacketizer.java
+++ b/src/org/jitsi/impl/neomedia/codec/video/h264/DePacketizer.java
@@ -617,7 +617,7 @@ public class DePacketizer
         int lengthRemaining)
     {
         int initialLength = lengthRemaining;
-        while (lengthRemaining > 0 && offset + 1 < initialLength)
+        while (lengthRemaining > 0 && offset + 1 < initialLength && offset > 0)
         {
             // Buffer doesn't contain room for additional nalu length.
             if (lengthRemaining < kNalUSize)


### PR DESCRIPTION
This was left behind in our local branch related to
https://github.com/jitsi/libjitsi/pull/183