### PR TITLE
fix(rewriting): Fixes the RTP clock frequency calculation.

### DIFF
--- a/src/org/jitsi/impl/neomedia/rtcp/RemoteClockEstimator.java
+++ b/src/org/jitsi/impl/neomedia/rtcp/RemoteClockEstimator.java
@@ -127,7 +127,7 @@ public class RemoteClockEstimator
             // Calculate the clock frequency/rate.
             Timestamp oldTs = oldClock.getRemoteTimestamp();
             long rtpTimestampDiff
-                = rtptimestamp - oldTs.getRtpTimestampAsLong();
+                = TimeUtils.rtpDiff(rtptimestamp, oldTs.getRtpTimestampAsLong());
             long systemTimeMsDiff = systemTimeMs - oldTs.getSystemTimeMs();
 
             frequencyHz = Math.round(

--- a/src/org/jitsi/impl/neomedia/rtp/translator/OutputDataStreamImpl.java
+++ b/src/org/jitsi/impl/neomedia/rtp/translator/OutputDataStreamImpl.java
@@ -787,7 +787,7 @@ class OutputDataStreamImpl
                 ? rewriter.rewriteRTP(write, buf, off, len)
                 : rewriter.restoreRTP(buf, off, len);
 
-            if (logger.isDebugEnabled())
+            if (mod && logger.isDebugEnabled())
             {
                 logger.debug("post-" + (rewrite ? "rewrite" : "restore")
                     + " RTP ssrc=" + ssrc


### PR DESCRIPTION
Takes RTP timestamp wrap-around when calculating the RTP clock frequency.