### PR TITLE
Add support for media types listed in the IANA registry

### DIFF
--- a/src/org/jitsi/service/neomedia/MediaType.java
+++ b/src/org/jitsi/service/neomedia/MediaType.java
@@ -40,7 +40,16 @@ public enum MediaType
 
     /**
      * Represents a DATA media type.
+     * @deprecated In RFC4566. Still defined to avoid parsing errors.
      */
+    @Deprecated
+    CONTROL("control"),
+
+    /**
+     * Represents a DATA media type.
+     * @deprecated In RFC4566. Still defined to avoid parsing errors.
+     */
+    @Deprecated
     DATA("data");
 
     /**

--- a/src/org/jitsi/service/neomedia/MediaType.java
+++ b/src/org/jitsi/service/neomedia/MediaType.java
@@ -19,6 +19,10 @@ package org.jitsi.service.neomedia;
  * The <tt>MediaType</tt> enumeration contains a list of media types
  * currently known to and handled by the <tt>MediaService</tt>.
  *
+ * @see <a href="http://www.iana.org/assignments/sdp-parameters/sdp-parameters.xhtml#sdp-parameters-1">
+ *     Session Description Protocol (SDP) Parameters, media</a>
+ *
+ *
  * @author Emil Ivov
  */
 public enum MediaType
@@ -34,9 +38,24 @@ public enum MediaType
     VIDEO("video"),
 
     /**
+     * Represents a TEXT media type. See RFC4103.
+     */
+    TEXT("text"),
+
+    /**
+     * Represents an APPLICATION media type.
+     */
+    APPLICATION("application"),
+
+    /**
      * Represents a (chat-) MESSAGE media type.
      */
     MESSAGE("message"),
+
+    /**
+     * Represents an IMAGE media type. See RFC6466.
+     */
+    IMAGE("image"),
 
     /**
      * Represents a DATA media type.

--- a/src/org/jitsi/service/neomedia/MediaType.java
+++ b/src/org/jitsi/service/neomedia/MediaType.java
@@ -29,14 +29,14 @@ public enum MediaType
     AUDIO("audio"),
 
     /**
-     * Represents a (chat-) MESSAGE media type.
-     */
-    MESSAGE("message"),
-
-    /**
      * Represents a VIDEO media type.
      */
     VIDEO("video"),
+
+    /**
+     * Represents a (chat-) MESSAGE media type.
+     */
+    MESSAGE("message"),
 
     /**
      * Represents a DATA media type.


### PR DESCRIPTION
Jitsi currently fails to parse some INVITEs in a SIP call with valid media types. These new media types added to the enum are all listed in RFCs and we should be able to parse them without throwing an exception.

#1 introduced the MESSAGE media type and it didn't cause a break where we iterate over the enum. So this should be safe to merge as well.