### PR TITLE
[RemoteBitrateEstimator] Use the RTP extension abs-send-time to correctly calculate inter-departure time.

### DIFF
--- a/src/org/jitsi/impl/neomedia/RateLimiter.java
+++ b/src/org/jitsi/impl/neomedia/RateLimiter.java
@@ -1,0 +1,77 @@
+package org.jitsi.impl.neomedia;
+
+/**
+ * Simple backoff timer to limit the rate of operations.
+ *
+ * A simple usage may be to limit the frequency of error logging.
+ */
+public class RateLimiter
+{
+    private static final int DEFAULT_MIN_BACKOFF_MS = 10*1000;
+
+    private final TimeProvider timeProvider;
+
+    private int minBackoffMs;
+    private int lastUsedInstantMs;
+
+    interface TimeProvider
+    {
+        long getTimeMs();
+    }
+
+    /**
+     * Constructor which uses the wall clock as the reference time.
+     */
+    public RateLimiter()
+    {
+        this(new TimeProvider()
+        {
+            @Override
+            public long getTimeMs()
+            {
+                return System.currentTimeMillis();
+            }
+        });
+    }
+
+    /**
+     * Constructor which injects a custom TimeProvider for unit testing.
+     */
+    RateLimiter(TimeProvider timeProvider)
+    {
+        this.timeProvider = timeProvider;
+        minBackoffMs = DEFAULT_MIN_BACKOFF_MS;
+        //noinspection NumericOverflow
+        lastUsedInstantMs = -(minBackoffMs + 1);
+    }
+
+    /**
+     * Controls if the rate limited operation should be run.
+     *
+     * Example:
+     * if (logNonFatalError.shouldRun()) {
+     *    logger.error("This is a non-fatal error message for which " +
+     *        "we want to print at least once and rate limit the frequency of printing."
+     * }
+     *
+     * @returns true if we should allow the rate limited operation to continue.
+     */
+    boolean shouldRun()
+    {
+        int nowMs = (int) (timeProvider.getTimeMs());
+        if (((nowMs - lastUsedInstantMs) & 0xffff_ffffL) > minBackoffMs)
+        {
+            lastUsedInstantMs = nowMs;
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * @return the minimum backoff time in milliseconds.
+     */
+    int getMinBackoffMs()
+    {
+        return minBackoffMs;
+    }
+}

--- a/src/org/jitsi/impl/neomedia/rtp/remotebitrateestimator/InterArrival.java
+++ b/src/org/jitsi/impl/neomedia/rtp/remotebitrateestimator/InterArrival.java
@@ -29,7 +29,7 @@ import org.jitsi.util.*;
  */
 class InterArrival
 {
-    private static final int kBurstDeltaThresholdMs  = 5;
+    private static final int kBurstDeltaThresholdMs = 5;
 
     private static final Logger logger = Logger.getLogger(InterArrival.class);
 
@@ -97,19 +97,14 @@ class InterArrival
                     "currentTimestampGroup.completeTimeMs");
         }
 
-        long arrivalTimeDeltaMs
-            = arrivalTimeMs - currentTimestampGroup.completeTimeMs;
-        long timestampDiff = timestamp - currentTimestampGroup.timestamp;
-        long tsDeltaMs = (long) (timestampToMsCoeff * timestampDiff + 0.5);
-
-        if (tsDeltaMs == 0)
-            return true;
-
-        long propagationDeltaMs = arrivalTimeDeltaMs - tsDeltaMs;
-
         return
-            propagationDeltaMs < 0
-                && arrivalTimeDeltaMs <= kBurstDeltaThresholdMs;
+            TimestampUtils.belongsToBurst(
+                arrivalTimeMs,
+                timestamp,
+                currentTimestampGroup.completeTimeMs,
+                currentTimestampGroup.timestamp,
+                timestampToMsCoeff,
+                kBurstDeltaThresholdMs);
     }
 
     /**

--- a/src/org/jitsi/impl/neomedia/rtp/remotebitrateestimator/RemoteBitrateEstimatorSingleStream.java
+++ b/src/org/jitsi/impl/neomedia/rtp/remotebitrateestimator/RemoteBitrateEstimatorSingleStream.java
@@ -85,12 +85,6 @@ public class RemoteBitrateEstimatorSingleStream
         this.observer = observer;
     }
 
-    private long getExtensionTransmissionTimeOffset(RTPPacket header)
-    {
-        // TODO Auto-generated method stub
-        return 0;
-    }
-
     /**
      * {@inheritDoc}
      */

--- a/src/org/jitsi/impl/neomedia/rtp/remotebitrateestimator/TimestampUtils.java
+++ b/src/org/jitsi/impl/neomedia/rtp/remotebitrateestimator/TimestampUtils.java
@@ -68,4 +68,38 @@ class TimestampUtils
             isNewerTimestamp(timestamp1, timestamp2) ? timestamp1 : timestamp2;
     }
 
+    /**
+     * Calculate the departure and arrival time delta to determine if the new packet belongs to a burst
+     *
+     * @param packetArrivalTimeMs
+     * @param packetDepartureTimestamp
+     * @param currentGroupCompleteTimeMs
+     * @param currentGroupDepartureTimestamp
+     * @param timestampToMsCoeff
+     * @param kBurstDeltaThresholdMs
+     * @return
+     */
+    static boolean belongsToBurst(
+        long packetArrivalTimeMs,
+        long packetDepartureTimestamp,
+        long currentGroupCompleteTimeMs,
+        long currentGroupDepartureTimestamp,
+        double timestampToMsCoeff,
+        int kBurstDeltaThresholdMs)
+    {
+        long arrivalTimeDeltaMs
+            = packetArrivalTimeMs - currentGroupCompleteTimeMs;
+        long timestampDiff = packetDepartureTimestamp - currentGroupDepartureTimestamp;
+        long tsDeltaMs = (long) (timestampToMsCoeff * timestampDiff + 0.5);
+
+        if (tsDeltaMs == 0)
+            return true;
+
+        long propagationDeltaMs = arrivalTimeDeltaMs - tsDeltaMs;
+
+        return
+            propagationDeltaMs < 0
+                && arrivalTimeDeltaMs <= kBurstDeltaThresholdMs;
+
+    }
 }

--- a/src/org/jitsi/impl/neomedia/rtp/remotebitrateestimator/TimestampUtils.java
+++ b/src/org/jitsi/impl/neomedia/rtp/remotebitrateestimator/TimestampUtils.java
@@ -69,15 +69,15 @@ class TimestampUtils
     }
 
     /**
-     * Calculate the departure and arrival time delta to determine if the new packet belongs to a burst
+     * Determine if a new packet is part of the current burst.
      *
-     * @param packetArrivalTimeMs
-     * @param packetDepartureTimestamp
-     * @param currentGroupCompleteTimeMs
-     * @param currentGroupDepartureTimestamp
-     * @param timestampToMsCoeff
-     * @param kBurstDeltaThresholdMs
-     * @return
+     * @param packetArrivalTimeMs Packet arrival time in milliseconds.
+     * @param packetDepartureTimestamp Packet departure time in units defined by timestampToMsCoeff.
+     * @param currentGroupCompleteTimeMs The last packet arrival time the current burst.
+     * @param currentGroupDepartureTimestamp The last packet departure timestamp of the current burst in units defined by timestampToMsCoeff.
+     * @param timestampToMsCoeff Packet departure times may be converted to milliseconds using this coefficient.
+     * @param kBurstDeltaThresholdMs The threshold in milliseconds which defines a new burst.
+     * @return True if the packet belongs to the current burst.
      */
     static boolean belongsToBurst(
         long packetArrivalTimeMs,

--- a/src/org/jitsi/service/neomedia/rtp/RemoteBitrateEstimator.java
+++ b/src/org/jitsi/service/neomedia/rtp/RemoteBitrateEstimator.java
@@ -59,30 +59,15 @@ public interface RemoteBitrateEstimator
      * @param arrivalTimeMs can be of an arbitrary time base
      * @param payloadSize the packet size excluding headers
      * @param ssrc
-     * @param rtpTimestamp
+     * @param absSendTime24Bit Timestamp in seconds, 24 bit 6.18 fixed point, yielding 64s wraparound and 3.8us resolution.
+     *      @see <a href=https://webrtc.org/experiments/rtp-hdrext/abs-send-time/>abs-send-time</a>
      * @param wasPaced
      */
     void incomingPacket(
             long arrivalTimeMs,
             int payloadSize,
             int ssrc,
-            long rtpTimestamp,
-            boolean wasPaced);
-
-    /**
-     * Called for each incoming packet. Updates the incoming payload bitrate
-     * estimate and the over-use detector. If an over-use is detected the remote
-     * bitrate estimate will be updated.
-     *
-     * @param arrivalTimeMs can be of an arbitrary time base
-     * @param payloadSize the packet size excluding headers
-     * @param header
-     * @param wasPaced
-     */
-    void incomingPacket(
-            long arrivalTimeMs,
-            int payloadSize,
-            RTPPacket header,
+            long absSendTime24Bit,
             boolean wasPaced);
 
     /**

--- a/test/org/jitsi/impl/neomedia/RateLimiterTest.java
+++ b/test/org/jitsi/impl/neomedia/RateLimiterTest.java
@@ -1,0 +1,73 @@
+package org.jitsi.impl.neomedia;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class RateLimiterTest
+{
+    abstract class SettableTimeProvider implements RateLimiter.TimeProvider
+    {
+        abstract public void setTimeMs(long timeMs);
+    }
+
+    private SettableTimeProvider settableTime = new SettableTimeProvider()
+    {
+        long timeMs;
+
+        public void setTimeMs(long timeMs)
+        {
+            this.timeMs = timeMs;
+        }
+
+        @Override
+        public long getTimeMs()
+        {
+            return timeMs;
+        }
+    };
+
+    private RateLimiter rateLimiter;
+
+    @Before
+    public void setup()
+    {
+        rateLimiter = new RateLimiter(settableTime);
+    }
+
+
+    @Test
+    public void testInitialState()
+    {
+        settableTime.setTimeMs(0);
+        assertTrue(rateLimiter.shouldRun());
+    }
+
+    @Test
+    public void testDenyRun()
+    {
+        settableTime.setTimeMs(0);
+        assertTrue(rateLimiter.shouldRun());
+        assertFalse(rateLimiter.shouldRun());
+        settableTime.setTimeMs(rateLimiter.getMinBackoffMs() - 1);
+        assertFalse(rateLimiter.shouldRun());
+    }
+
+    @Test
+    public void testAllowRunAfterBackoffPeriod()
+    {
+        settableTime.setTimeMs(0);
+        assertTrue(rateLimiter.shouldRun());
+        settableTime.setTimeMs(rateLimiter.getMinBackoffMs());
+        assertFalse(rateLimiter.shouldRun());
+    }
+
+    @Test
+    public void testRollover()
+    {
+        settableTime.setTimeMs(Integer.MIN_VALUE);
+        assertTrue(rateLimiter.shouldRun());
+    }
+}

--- a/test/org/jitsi/impl/neomedia/RawPacketTest.java
+++ b/test/org/jitsi/impl/neomedia/RawPacketTest.java
@@ -1,0 +1,72 @@
+package org.jitsi.impl.neomedia;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.StringReader;
+
+import static org.junit.Assert.assertEquals;
+
+public class RawPacketTest
+{
+    private byte[] buildPacketWithAbsSendTime(int absSendTime)
+    {
+        String sendTime = String.format("%04x", absSendTime);
+        String data = "90ff2a156c67726096b37210bede000132" + sendTime + "98ad90a8523ccaa4313550c71e6a01";
+        return buildPacket(data);
+    }
+
+    private static byte[] buildPacket(String hexString)
+    {
+        StringReader reader = new StringReader(hexString);
+        char[] data = new char[2];
+        byte[] buffer = new byte[hexString.length() / 2];
+        int i = 0;
+        try
+        {
+            while (reader.read(data, 0, 2) != -1)
+            {
+                buffer[i++] = (byte)Integer.parseInt(String.valueOf(data), 16);
+            }
+        }
+        catch (IOException e)
+        {
+            e.printStackTrace();
+        }
+        return buffer;
+    }
+
+    @Test
+    public void testGetAbsSendTime()
+    {
+        final int MAGIC_ABS_SEND_TIME = 0x734d77;
+        byte[] data = buildPacketWithAbsSendTime(MAGIC_ABS_SEND_TIME);
+        RawPacket packet = new RawPacket(data, 0, data.length);
+        assertEquals(MAGIC_ABS_SEND_TIME, packet.getAbsSendTime());
+    }
+
+    @Test
+    public void testGetAbsSendTimeSignExtension()
+    {
+        final int LEADING_BITS = 0x818283;
+        byte[] data = buildPacketWithAbsSendTime(LEADING_BITS);
+        RawPacket packet = new RawPacket(data, 0, data.length);
+        assertEquals(LEADING_BITS, packet.getAbsSendTime());
+    }
+
+    @Test
+    public void testGetAbsSentTimeEmptyPacket()
+    {
+        RawPacket packet = new RawPacket(new byte[] {}, 0, 0);
+        assertEquals(-1, packet.getAbsSendTime());
+    }
+
+    @Test
+    public void testGetAbsSentTimeIncompletePacket()
+    {
+        final String incompletePacket = "90ff2a156c67726096b37210bede000132734d";
+        final byte[] incompletePacketBytes = buildPacket(incompletePacket);
+        RawPacket packet = new RawPacket(incompletePacketBytes, 0, 35);
+        assertEquals(-1, packet.getAbsSendTime());
+    }
+}


### PR DESCRIPTION
Jitsi uses the RTP timestamp for the calculation of inter-departure
time.  This is not ideal because the RTP timestamp is recorded before
the pacer introduces artificial delay in the inter-arrival times.  We
fixed this by doing the same as Chrome does and use the RTP extension
abs-send-time to calculate deltas in the remote bitrate estimator.

With calls on jitsi, the bitrate sometimes will unexpectedly drop.  This is
most noticeable with screenshare content in the following scenario:

1) Artificially high inter-group delay variation (d(i) in draft-ietf-rmcat-gcc-02)
because the departure times are recorded before the pacer queue.  Overuse is asserted.
2) If overuse occurs during a static screenshare scene, the bitrate
drops to 30kbps due to a ratcheting down to the low incoming bitrate.
3) High dynamic scene changes then cause the encoded bitrate to far
exceed the target bitrate.
4) The pacer limits the transmit rate to the target bitrate which can
cause the packets to be sent out over an interval of 5-10 seconds.

Test Plan:
Unit test covering the affected logic when we move to the 24-bit abs-send-time.
Manual tests of scenarios where the bitrate drop to 30kbps caused high
screenshare latency.