### PR TITLE
[stats] Record rate control statistics.

### DIFF
--- a/src/org/jitsi/impl/neomedia/MediaStreamImpl.java
+++ b/src/org/jitsi/impl/neomedia/MediaStreamImpl.java
@@ -193,6 +193,11 @@ public class MediaStreamImpl
     private MediaStreamStats2Impl mediaStreamStatsImpl;
 
     /**
+     * Contains statistics about this <tt>MediaStreamImpl</tt> used for telemetry and debugging.
+     */
+    private final StatisticsTable statisticsTable;
+
+    /**
      * The indicator which determines whether this <tt>MediaStream</tt> is set
      * to transmit "silence" instead of the actual media fed from its
      * <tt>MediaDevice</tt>.
@@ -411,6 +416,7 @@ public class MediaStreamImpl
 
         this.srtpControl.registerUser(this);
         this.mediaStreamStatsImpl = new MediaStreamStats2Impl(this);
+        this.statisticsTable = new StatisticsTable();
 
         if (connector != null)
             setConnector(connector);
@@ -1638,6 +1644,18 @@ public class MediaStreamImpl
     public MediaStreamStats2Impl getMediaStreamStats()
     {
         return mediaStreamStatsImpl;
+    }
+
+    /**
+     * Returns the <tt>StatisticsTable</tt> which contains
+     * additional statistical information about this <tt>MediaStream</tt>.
+     *
+     * @return <tt>StatisticsTable</tt>
+     */
+    @Override
+    public StatisticsTable getStatisticsTable()
+    {
+        return statisticsTable;
     }
 
     /**

--- a/src/org/jitsi/impl/neomedia/VideoMediaStreamImpl.java
+++ b/src/org/jitsi/impl/neomedia/VideoMediaStreamImpl.java
@@ -438,7 +438,8 @@ public class VideoMediaStreamImpl
                                     ssrcs,
                                     bitrate);
                     }
-                });
+                },
+                getStatisticsTable());
 
     /**
      * The facility which aids this instance in managing a list of
@@ -1364,7 +1365,7 @@ public class VideoMediaStreamImpl
     {
         if (bandwidthEstimator == null)
         {
-            bandwidthEstimator = new BandwidthEstimatorImpl(this);
+            bandwidthEstimator = new BandwidthEstimatorImpl(this, getStatisticsTable());
             recurringRunnableExecutor.registerRecurringRunnable(
                     bandwidthEstimator);
             logger.info("Creating a BandwidthEstimator for stream " + this);

--- a/src/org/jitsi/impl/neomedia/java8/BiFunction.java
+++ b/src/org/jitsi/impl/neomedia/java8/BiFunction.java
@@ -1,0 +1,9 @@
+package org.jitsi.impl.neomedia.java8;
+
+/**
+ * Similar to Java 1.8's BiFunction.
+ */
+public interface BiFunction<T,U,V>
+{
+    V apply(T var, U var2);
+}

--- a/src/org/jitsi/impl/neomedia/java8/Function.java
+++ b/src/org/jitsi/impl/neomedia/java8/Function.java
@@ -1,0 +1,10 @@
+package org.jitsi.impl.neomedia.java8;
+
+
+/**
+ * Similar to Java 1.8's Function
+ */
+public interface Function<T, R>
+{
+    R apply(T var);
+}

--- a/src/org/jitsi/impl/neomedia/java8/MapExtension.java
+++ b/src/org/jitsi/impl/neomedia/java8/MapExtension.java
@@ -1,0 +1,29 @@
+package org.jitsi.impl.neomedia.java8;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Utility functions to give Maps functionality similar to Java 1.8.
+ */
+public class MapExtension
+{
+    /**
+     * Implements similar functionality to the Java 1.8 computeIfAbsent
+     */
+    public static <K,V> V computeIfAbsent(ConcurrentHashMap<K,V> map, K key, Function<K,V> defaultValue)
+    {
+        V value = map.get(key);
+        if (null == value)
+        {
+            V newValue = defaultValue.apply(key);
+            value = map.putIfAbsent(key, newValue);
+            if (value == null)
+            {
+                value = newValue;
+            }
+        }
+        return value;
+    }
+}

--- a/src/org/jitsi/impl/neomedia/java8/Optional.java
+++ b/src/org/jitsi/impl/neomedia/java8/Optional.java
@@ -1,0 +1,85 @@
+package org.jitsi.impl.neomedia.java8;
+
+import java.util.NoSuchElementException;
+import java.util.Objects;
+
+/**
+ * Jitsi version of Java 1.8 Optional to allow code to have the same expressive elegance.
+ */
+public final class Optional<T>
+{
+    private static final Optional<?> EMPTY = new Optional<>();
+    private final T value;
+
+    private Optional()
+    {
+        value = null;
+    }
+
+    private Optional(T value)
+    {
+        this.value = Objects.requireNonNull(value);
+    }
+
+
+    public static <T> Optional<T> of(T value)
+    {
+        return new Optional<>(value);
+    }
+
+
+    public static <T> Optional<T> ofNullable(T value)
+    {
+        return (null == value) ? Optional.<T>empty() : of(value);
+    }
+
+    public static<T> Optional<T> empty()
+    {
+        @SuppressWarnings("unchecked")
+        Optional<T> optional = (Optional<T>)EMPTY;
+        return optional;
+    }
+
+    public T get()
+    {
+        return Objects.requireNonNull(value);
+    }
+
+    public boolean isPresent()
+    {
+        return null != value;
+    }
+
+    public T orElse(T other)
+    {
+        return (null == value) ? other : value;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (o == this)
+        {
+            return true;
+        }
+        if (!(o instanceof Optional))
+        {
+            return false;
+        }
+        @SuppressWarnings("unchecked")
+        Optional<T> other = (Optional<T>)o;
+        return value != null && value.equals(other.value);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hashCode(value);
+    }
+
+    @Override
+    public String toString()
+    {
+        return (null == value) ? "empty" : "Optional[" + value + "]";
+    }
+}

--- a/src/org/jitsi/impl/neomedia/rtp/remotebitrateestimator/RemoteBitrateEstimatorSingleStream.java
+++ b/src/org/jitsi/impl/neomedia/rtp/remotebitrateestimator/RemoteBitrateEstimatorSingleStream.java
@@ -245,7 +245,7 @@ public class RemoteBitrateEstimatorSingleStream
         } // synchronized (critSect)
     }
 
-    private void recordArrivalFilterStats(long ssrc, long deltaArrivalTimeMs, double deltaDepartureTimeMs,
+    private void recordArrivalFilterStats(int ssrc, long deltaArrivalTimeMs, double deltaDepartureTimeMs,
             long deltaSizeBytes, double estimatedGroupDelayVariationMs, int numOfDeltas)
     {
         double deltaGroupDelayVariationMs = deltaArrivalTimeMs - deltaDepartureTimeMs;

--- a/src/org/jitsi/impl/neomedia/rtp/sendsidebandwidthestimation/BandwidthEstimatorImpl.java
+++ b/src/org/jitsi/impl/neomedia/rtp/sendsidebandwidthestimation/BandwidthEstimatorImpl.java
@@ -16,6 +16,7 @@
 package org.jitsi.impl.neomedia.rtp.sendsidebandwidthestimation;
 
 import net.sf.fmj.media.rtp.*;
+import org.jitsi.impl.neomedia.stats.StatisticsTable;
 import org.jitsi.service.neomedia.*;
 import org.jitsi.service.neomedia.rtp.*;
 import org.jitsi.util.concurrent.*;
@@ -79,11 +80,11 @@ public class BandwidthEstimatorImpl
      * {@link MediaStream}.
      * @param stream the {@link MediaStream}.
      */
-    public BandwidthEstimatorImpl(MediaStream stream)
+    public BandwidthEstimatorImpl(MediaStream stream, StatisticsTable statisticsTable)
     {
         mediaStream = stream;
         sendSideBandwidthEstimation
-            = new SendSideBandwidthEstimation(stream, START_BITRATE_BPS);
+            = new SendSideBandwidthEstimation(stream, START_BITRATE_BPS, statisticsTable);
         sendSideBandwidthEstimation.setMinMaxBitrate(
                 MIN_BITRATE_BPS, MAX_BITRATE_BPS);
 

--- a/src/org/jitsi/impl/neomedia/rtp/sendsidebandwidthestimation/SendSideBandwidthEstimation.java
+++ b/src/org/jitsi/impl/neomedia/rtp/sendsidebandwidthestimation/SendSideBandwidthEstimation.java
@@ -15,11 +15,15 @@
  */
 package org.jitsi.impl.neomedia.rtp.sendsidebandwidthestimation;
 
+import org.jitsi.impl.neomedia.stats.StatisticsTable;
 import org.jitsi.service.neomedia.*;
 import org.jitsi.service.neomedia.rtp.*;
 import org.jitsi.util.*;
 
 import java.util.*;
+
+import static org.jitsi.impl.neomedia.stats.CounterName.AVAILABLE_SEND_BANDWIDTH_BPS;
+import static org.jitsi.impl.neomedia.stats.CounterName.RECEIVER_ESTIMATED_MAXIMUM_BITRATE_BPS;
 
 /**
  * Implements the send-side bandwidth estimation described in
@@ -138,10 +142,12 @@ class SendSideBandwidthEstimation
      * The {@link MediaStream} for this {@link SendSideBandwidthEstimation}.
      */
     private final MediaStream mediaStream;
+    private final StatisticsTable stats;
 
-    SendSideBandwidthEstimation(MediaStream stream, long startBitrate)
+    SendSideBandwidthEstimation(MediaStream stream, long startBitrate, StatisticsTable stats)
     {
         mediaStream = stream;
+        this.stats = stats;
         setBitrate(startBitrate);
     }
 
@@ -310,6 +316,7 @@ class SendSideBandwidthEstimation
      */
     private synchronized void updateReceiverEstimate(long bandwidth)
     {
+        stats.get(RECEIVER_ESTIMATED_MAXIMUM_BITRATE_BPS).set(bandwidth);
         bwe_incoming_ = bandwidth;
         setBitrate(capBitrateToThresholds(bitrate_));
     }
@@ -342,6 +349,7 @@ class SendSideBandwidthEstimation
         if (oldValue != bitrate_)
         {
             fireBandwidthEstimationChanged(oldValue, newValue);
+            stats.get(AVAILABLE_SEND_BANDWIDTH_BPS).set(bitrate_);
         }
     }
 

--- a/src/org/jitsi/impl/neomedia/stats/ConcurrentMultiKeyMap.java
+++ b/src/org/jitsi/impl/neomedia/stats/ConcurrentMultiKeyMap.java
@@ -1,0 +1,104 @@
+package org.jitsi.impl.neomedia.stats;
+
+import org.jitsi.impl.neomedia.java8.BiFunction;
+import org.jitsi.impl.neomedia.java8.MapExtension;
+import org.jitsi.impl.neomedia.java8.Function;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * A specialized map implementation that uses multiple keys to map the value.
+ *
+ * This implementation optimizes for get and put operations that do not involve the
+ * creation of objects---an attempt to make a high volume of operations be GC wait free.
+ *
+ * This implementation may be inefficient if the set size of K1 is large.
+ */
+public class ConcurrentMultiKeyMap<K1,K2,V>
+{
+    private final ConcurrentHashMap<K1, ConcurrentHashMap<K2, V>> map;
+
+    public ConcurrentMultiKeyMap() {
+        this.map = new ConcurrentHashMap<>();
+    }
+
+    /**
+     * Obtain the map of secondary key to value of all mappings
+     * where the primary key is the specified key.
+     */
+    public ConcurrentHashMap<K2,V> get(K1 key1)
+    {
+        return populateSubMapIfAbsent(key1);
+    }
+
+    /**
+     * Return the value for the specified key or <tt>null</tt> if this map
+     * contains no mapping for this key.
+     */
+    public V get(K1 key1, K2 key2)
+    {
+        Map<K2, V> subMap = populateSubMapIfAbsent(key1);
+        return subMap.get(key2);
+    }
+
+    private ConcurrentHashMap<K2,V> populateSubMapIfAbsent(K1 key1)
+    {
+        return MapExtension.computeIfAbsent(map, key1, new Function<K1, ConcurrentHashMap<K2, V>>()
+        {
+            @Override
+            public ConcurrentHashMap<K2, V> apply(K1 var)
+            {
+                return new ConcurrentHashMap<>();
+            }
+        });
+    }
+
+    /**
+     * If the specified key is not already associated with a value,
+     * associate it with the given value.
+     * Same as {@link ConcurrentMap.putIfAbsent} except with a multiple value key.
+     *
+     * @return previous value of associated with key or <tt>null</tt> if there was
+     *   no mapping for this key.
+     */
+    public V putIfAbsent(K1 key1, K2 key2, V value)
+    {
+        ConcurrentHashMap<K2,V> subMap = populateSubMapIfAbsent(key1);
+        return subMap.putIfAbsent(key2, value);
+    }
+
+    /**
+     * If the specified key is not already associated with a value, run
+     * the given mapping function and enter the value into the map.
+     * Same as Java 1.8 {@link ConcurrentMap.computeIfAbsent} except with a multiple value key.
+     *
+     * @return the current (existing or computed) value associated with the key,
+     *    or <tt>null</tt> if the computed value is <tt>null</tt>.
+     */
+    public V computeIfAbsent(K1 key1, K2 key2, BiFunction<K1,K2,V> defaultValue)
+    {
+        V value = get(key1, key2);
+        if (null == value)
+        {
+            V newValue = defaultValue.apply(key1, key2);
+            value = putIfAbsent(key1, key2, newValue);
+            if (value == null)
+            {
+                value = newValue;
+            }
+        }
+        return value;
+    }
+
+    /**
+     * Returns a {@link Set} view of the mappings contained in this map.
+     * The set is backed by the map, so changes to the map are
+     * reflected in the set, and vice-versa.
+     */
+    public Set<Map.Entry<K1,ConcurrentHashMap<K2, V>>> entrySet()
+    {
+        return map.entrySet();
+    }
+}

--- a/src/org/jitsi/impl/neomedia/stats/Counter.java
+++ b/src/org/jitsi/impl/neomedia/stats/Counter.java
@@ -1,0 +1,11 @@
+package org.jitsi.impl.neomedia.stats;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Contains a value which can atomically handle the operations:
+ * increment/decrement/set.
+ */
+public class Counter extends AtomicLong
+{
+}

--- a/src/org/jitsi/impl/neomedia/stats/CounterName.java
+++ b/src/org/jitsi/impl/neomedia/stats/CounterName.java
@@ -1,0 +1,47 @@
+package org.jitsi.impl.neomedia.stats;
+
+public enum CounterName {
+
+    /**
+     * AimdRateControl counters.
+     */
+
+    RATE_CONTROL_HOLD("rateControlHold"),
+    RATE_CONTROL_INCREASE("rateControlIncrease"),
+    RATE_CONTROL_DECREASE("rateControlDecrease"),
+    RATE_CONTROL_DROP_TO_MIN_BITRATE("rateControlDropToMinBitrate"),
+
+    /**
+     * RemoteBitrateEstimator counters.
+     */
+
+    TARGET_BITRATE_BPS("targetBitrateBps"),
+    DELTA_ARRIVAL_TIME_MS("deltaArrivalTimeMs"),
+    DELTA_DEPARTURE_TIME_MS("deltaDepartureTimeMs"),
+    DELTA_SIZE_BYTES("deltaSizeBytes"),
+    DELTA_GROUP_DELAY_VARIATION_MS("deltaGroupDelayVariationMs"),
+    ESTIMATED_DELTA_GROUP_DELAY_VARIATION_MS("estimatedDeltaGroupDelayVariationMs"),
+    ESTIMATION_NUM_DELTAS("estimationNumDeltas"),
+    INCOMING_BITRATE_BPS("incomingBitrateBps"),
+    BANDWIDTH_NORMAL("bandwidthNormal"),
+    BANDWIDTH_OVERUSE("bandwidthOveruse"),
+    BANDWIDTH_UNDERUSE("bandwidthUnderuse"),
+
+    /**
+     * SendSideBandwidthEstimation counters.
+     */
+
+    RECEIVER_ESTIMATED_MAXIMUM_BITRATE_BPS("receiverEstimatedMaximumBitrateBps"),
+    AVAILABLE_SEND_BANDWIDTH_BPS("availableSendBandwidthBps"),
+    ;
+
+    private final String name;
+
+    CounterName(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/src/org/jitsi/impl/neomedia/stats/StatisticsTable.java
+++ b/src/org/jitsi/impl/neomedia/stats/StatisticsTable.java
@@ -21,7 +21,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public class StatisticsTable
 {
     private final ConcurrentHashMap<String, Counter> map;
-    private final ConcurrentMultiKeyMap<Long, String, Counter> streamIdMap;
+    private final ConcurrentMultiKeyMap<Integer, String, Counter> streamIdMap;
     private final Optional<String> keyPrefix;
 
     /**
@@ -34,12 +34,12 @@ public class StatisticsTable
 
     private StatisticsTable(Optional<String> keyPrefix)
     {
-        this(keyPrefix, new ConcurrentHashMap<String, Counter>(), new ConcurrentMultiKeyMap<Long,String,Counter>());
+        this(keyPrefix, new ConcurrentHashMap<String, Counter>(), new ConcurrentMultiKeyMap<Integer,String,Counter>());
     }
 
     private StatisticsTable(Optional<String> keyPrefix,
                             ConcurrentHashMap<String, Counter> map,
-                            ConcurrentMultiKeyMap<Long, String, Counter> streamIdMap)
+                            ConcurrentMultiKeyMap<Integer, String, Counter> streamIdMap)
     {
         this.keyPrefix = keyPrefix;
         this.map = map;
@@ -71,16 +71,16 @@ public class StatisticsTable
     /**
      * Obtain a counter by streamId and String name.
      * This method is provided for debugging flexibility, but it is recommended
-     * that you use {@link get(long,CounterName)} for official counters.
+     * that you use {@link #get(int,CounterName)} for official counters.
      */
-    public Counter get(long streamId, String name)
+    public Counter get(int streamId, String name)
     {
         return streamIdMap.computeIfAbsent(
             streamId, append(keyPrefix, name),
-            new BiFunction<Long, String, Counter>()
+            new BiFunction<Integer, String, Counter>()
             {
                 @Override
-                public Counter apply(Long id, String specifier)
+                public Counter apply(Integer id, String specifier)
                 {
                     return new Counter();
                 }
@@ -93,7 +93,7 @@ public class StatisticsTable
      * typechecked correctness for counter definition as well
      * as future proof additional counter options in the future.
      */
-    public Counter get(long streamId, CounterName name)
+    public Counter get(int streamId, CounterName name)
     {
         return get(streamId, name.getName());
     }
@@ -111,7 +111,7 @@ public class StatisticsTable
      *  counter.get(CounterName.RATE_CONTROL_INCREASE).incrementAndGet();
      * }</pre>
      */
-    public GetCounterWithStreamId get(final long streamId)
+    public GetCounterWithStreamId get(final int streamId)
     {
         final StatisticsTable table = this;
         return new GetCounterWithStreamId() {
@@ -134,7 +134,7 @@ public class StatisticsTable
     /**
      * Obtain a Counter by string that is unassociated with any specific streamId.
      * This method is provided for debugging flexibility, but it is recommended
-     * that you use {@link get(CounterName)} for official counters.
+     * that you use {@link #get(CounterName)} for official counters.
      */
     public Counter get(String specifier)
     {
@@ -169,7 +169,7 @@ public class StatisticsTable
     public Map<Key,Long> toMap()
     {
         Map<Key, Long> result = new HashMap<>();
-        for (Map.Entry<Long, ConcurrentHashMap<String, Counter>> entry : streamIdMap.entrySet())
+        for (Map.Entry<Integer, ConcurrentHashMap<String, Counter>> entry : streamIdMap.entrySet())
         {
             for  (Map.Entry<String, Counter> counterEntry : entry.getValue().entrySet())
             {
@@ -179,7 +179,7 @@ public class StatisticsTable
         }
         for (Map.Entry<String, Counter> entry: map.entrySet())
         {
-            Key key = new Key(Optional.<Long>empty(), entry.getKey());
+            Key key = new Key(Optional.<Integer>empty(), entry.getKey());
             result.put(key, entry.getValue().get());
         }
         return result;
@@ -190,16 +190,16 @@ public class StatisticsTable
      */
     public static class Key
     {
-        private Optional<Long> streamId;
+        private Optional<Integer> streamId;
         private String name;
 
-        public Key(Optional<Long> streamId, String name)
+        public Key(Optional<Integer> streamId, String name)
         {
             this.streamId = streamId;
             this.name = name;
         }
 
-        public Optional<Long> getStreamId()
+        public Optional<Integer> getStreamId()
         {
             return streamId;
         }

--- a/src/org/jitsi/impl/neomedia/stats/StatisticsTable.java
+++ b/src/org/jitsi/impl/neomedia/stats/StatisticsTable.java
@@ -1,0 +1,229 @@
+package org.jitsi.impl.neomedia.stats;
+
+import org.jitsi.impl.neomedia.java8.BiFunction;
+import org.jitsi.impl.neomedia.java8.Function;
+import org.jitsi.impl.neomedia.java8.MapExtension;
+import org.jitsi.impl.neomedia.java8.Optional;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * A table which stores client counter values with multiple key formats.
+ *
+ * Supported key formats:
+ * 1) string - for statistics that pertain to no specific stream.
+ * 2) (stream-id, string) - for statistics that pertain to a specific stream.
+ *
+ * The keys only need to be unique within a given client.
+ */
+public class StatisticsTable
+{
+    private final ConcurrentHashMap<String, Counter> map;
+    private final ConcurrentMultiKeyMap<Long, String, Counter> streamIdMap;
+    private final Optional<String> keyPrefix;
+
+    /**
+     * Constructs a root statistics table.
+     */
+    public StatisticsTable()
+    {
+        this(Optional.<String>empty());
+    }
+
+    private StatisticsTable(Optional<String> keyPrefix)
+    {
+        this(keyPrefix, new ConcurrentHashMap<String, Counter>(), new ConcurrentMultiKeyMap<Long,String,Counter>());
+    }
+
+    private StatisticsTable(Optional<String> keyPrefix,
+                            ConcurrentHashMap<String, Counter> map,
+                            ConcurrentMultiKeyMap<Long, String, Counter> streamIdMap)
+    {
+        this.keyPrefix = keyPrefix;
+        this.map = map;
+        this.streamIdMap = streamIdMap;
+    }
+
+    /**
+     * Creates a view of this statistic table with a different key prefix.
+     * Any modifications to the underlying maps are reflected in the primary
+     * StatisticsTable.
+     */
+    public StatisticsTable withKeyPrefix(String prefix)
+    {
+        return new StatisticsTable(Optional.of(prefix), map, streamIdMap);
+    }
+
+    private static String append(Optional<String> prefix, String key)
+    {
+        if (prefix.isPresent())
+        {
+            return String.format("%s.%s", prefix.get(), key);
+        }
+        else
+        {
+            return key;
+        }
+    }
+
+    /**
+     * Obtain a counter by streamId and String name.
+     * This method is provided for debugging flexibility, but it is recommended
+     * that you use {@link get(long,CounterName)} for official counters.
+     */
+    public Counter get(long streamId, String name)
+    {
+        return streamIdMap.computeIfAbsent(
+            streamId, append(keyPrefix, name),
+            new BiFunction<Long, String, Counter>()
+            {
+                @Override
+                public Counter apply(Long id, String specifier)
+                {
+                    return new Counter();
+                }
+            });
+    }
+
+    /**
+     * Obtain a counter by streamId and CounterName.
+     * Any official counters should use this method to enable
+     * typechecked correctness for counter definition as well
+     * as future proof additional counter options in the future.
+     */
+    public Counter get(long streamId, CounterName name)
+    {
+        return get(streamId, name.getName());
+    }
+
+    /**
+     * Obtains a getter function to obtain the counters associated
+     * with a specific streamId.
+     * This allows for efficiency when referencing multiple counters
+     * of the same streamId.
+     *
+     * Example:
+     * <pre>{@code
+     *  GetCounterWithStreamId counter = stastisticsTable.get(streamId);
+     *  counter.get(CounterName.RATE_CONTROL_HOLD).incrementAndGet();
+     *  counter.get(CounterName.RATE_CONTROL_INCREASE).incrementAndGet();
+     * }</pre>
+     */
+    public GetCounterWithStreamId get(final long streamId)
+    {
+        final StatisticsTable table = this;
+        return new GetCounterWithStreamId() {
+            @Override
+            public Counter get(String name) {
+                return table.get(streamId, name);
+            }
+        };
+    }
+
+    public abstract class GetCounterWithStreamId
+    {
+        abstract public Counter get(String name);
+
+        public Counter get(CounterName name) {
+            return get(name.getName());
+        }
+    }
+
+    /**
+     * Obtain a Counter by string that is unassociated with any specific streamId.
+     * This method is provided for debugging flexibility, but it is recommended
+     * that you use {@link get(CounterName)} for official counters.
+     */
+    public Counter get(String specifier)
+    {
+        return MapExtension.computeIfAbsent(map,
+            append(keyPrefix, specifier),
+            new Function<String, Counter>()
+            {
+                @Override
+                public Counter apply(String specifier)
+                {
+                    return new Counter();
+                }
+            });
+    }
+
+    /**
+     * Obtain a Counter by CounterName which is unassociate with any specific
+     * streamId.
+     * Any official counters should use this method to enable
+     * typechecked correctness for counter definition as well
+     * as future proof additional counter options in the future.
+     */
+    public Counter get(CounterName name) {
+        return get(name.getName());
+    }
+
+    /**
+     * Returns a single map view of the statisics table.
+     *
+     * This operation allocates Key objects which contains the muti-key parameters.
+     */
+    public Map<Key,Long> toMap()
+    {
+        Map<Key, Long> result = new HashMap<>();
+        for (Map.Entry<Long, ConcurrentHashMap<String, Counter>> entry : streamIdMap.entrySet())
+        {
+            for  (Map.Entry<String, Counter> counterEntry : entry.getValue().entrySet())
+            {
+                Key key = new Key(Optional.of(entry.getKey()), counterEntry.getKey());
+                result.put(key, counterEntry.getValue().get());
+            }
+        }
+        for (Map.Entry<String, Counter> entry: map.entrySet())
+        {
+            Key key = new Key(Optional.<Long>empty(), entry.getKey());
+            result.put(key, entry.getValue().get());
+        }
+        return result;
+    }
+
+    /**
+     * A multi-value key which is used to map counter values.
+     */
+    public static class Key
+    {
+        private Optional<Long> streamId;
+        private String name;
+
+        public Key(Optional<Long> streamId, String name)
+        {
+            this.streamId = streamId;
+            this.name = name;
+        }
+
+        public Optional<Long> getStreamId()
+        {
+            return streamId;
+        }
+
+        public String getName()
+        {
+            return name;
+        }
+
+        @Override
+        public boolean equals(Object obj)
+        {
+            if (obj instanceof Key)
+            {
+                Key other = (Key)obj;
+                return streamId.equals(other.getStreamId()) && name.equals(other.getName());
+            }
+            return false;
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return streamId.hashCode() * 31 + name.hashCode();
+        }
+    }
+}

--- a/src/org/jitsi/service/neomedia/AbstractMediaStream.java
+++ b/src/org/jitsi/service/neomedia/AbstractMediaStream.java
@@ -21,6 +21,7 @@ import org.jitsi.impl.neomedia.*;
 import org.jitsi.impl.neomedia.codec.*;
 import org.jitsi.impl.neomedia.rtcp.termination.strategies.*;
 import org.jitsi.impl.neomedia.rtp.*;
+import org.jitsi.impl.neomedia.stats.StatisticsTable;
 import org.jitsi.impl.neomedia.transform.*;
 import org.jitsi.service.neomedia.format.*;
 

--- a/src/org/jitsi/service/neomedia/MediaStream.java
+++ b/src/org/jitsi/service/neomedia/MediaStream.java
@@ -22,6 +22,7 @@ import java.util.*;
 import org.jitsi.impl.neomedia.*;
 import org.jitsi.impl.neomedia.codec.*;
 import org.jitsi.impl.neomedia.rtp.*;
+import org.jitsi.impl.neomedia.stats.StatisticsTable;
 import org.jitsi.impl.neomedia.transform.*;
 import org.jitsi.service.neomedia.device.*;
 import org.jitsi.service.neomedia.format.*;
@@ -217,6 +218,12 @@ public interface MediaStream
      * this <tt>MediaStream</tt>.
      */
     MediaStreamStats2 getMediaStreamStats();
+
+    /**
+     * @return Returns a <tt>StatisticsTable</tt> object used to get additional counters about
+     * this <tt>MediaStream</tt>.
+     */
+    public StatisticsTable getStatisticsTable();
 
     /**
      * Returns the name of this stream or <tt>null</tt> if no name has been

--- a/test/org/jitsi/impl/neomedia/java8/MapExtensionTest.java
+++ b/test/org/jitsi/impl/neomedia/java8/MapExtensionTest.java
@@ -1,0 +1,38 @@
+package org.jitsi.impl.neomedia.java8;
+
+import org.junit.Test;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.junit.Assert.assertEquals;
+
+public class MapExtensionTest
+{
+    private static final Integer MAGIC = 0xd0b;
+    private static final Integer MAGIC_TWO = 0xd0bd0b;
+
+    private final ConcurrentHashMap<Integer, Integer> map = new ConcurrentHashMap<>();
+
+
+    @Test
+    public void testComputeIfAbsent() {
+        Integer value = MapExtension.computeIfAbsent(map, 0, new Function<Integer, Integer>() {
+            @Override
+            public Integer apply(Integer var) {
+                return MAGIC;
+            }
+        });
+        assertEquals(MAGIC, value);
+        computeIfAbsentShouldNoopComputeForSecondCall();
+    }
+
+    private void computeIfAbsentShouldNoopComputeForSecondCall() {
+        Integer value = MapExtension.computeIfAbsent(map, 0, new Function<Integer, Integer>() {
+            @Override
+            public Integer apply(Integer var) {
+                return MAGIC_TWO;
+            }
+        });
+        assertEquals(MAGIC, value);
+    }
+}

--- a/test/org/jitsi/impl/neomedia/java8/OptionalTest.java
+++ b/test/org/jitsi/impl/neomedia/java8/OptionalTest.java
@@ -1,0 +1,109 @@
+package org.jitsi.impl.neomedia.java8;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class OptionalTest {
+
+    private static final Integer MAGIC = 0xd0d0;
+    private static final Integer OTHER_MAGIC = 0x9d9d;
+
+    @Test(expected=NullPointerException.class)
+    public void testOfNullExpectsNullPointerException()
+    {
+        Optional.of(null);
+    }
+
+    @Test
+    public void testOfNullableNullObject()
+    {
+        Optional<?> nullOption = Optional.ofNullable(null);
+        assertEquals(Optional.empty(), nullOption);
+    }
+
+    @Test
+    public void testOfNullable()
+    {
+        Optional<?> a = Optional.ofNullable(MAGIC);
+        assertEquals(MAGIC, a.get());
+    }
+
+    @Test
+    public void testIsPresent()
+    {
+        assertFalse(Optional.empty().isPresent());
+        assertTrue(Optional.of(MAGIC).isPresent());
+    }
+
+    @Test
+    public void testGet()
+    {
+        assertEquals(MAGIC, Optional.of(MAGIC).get());
+    }
+
+    @Test(expected=NullPointerException.class)
+    public void testGetExpectNullPointerException()
+    {
+        Optional.empty().get();
+    }
+
+    @Test
+    public void testOrElse()
+    {
+        assertEquals(MAGIC, Optional.of(MAGIC).orElse(OTHER_MAGIC));
+        assertEquals(OTHER_MAGIC, Optional.empty().orElse(OTHER_MAGIC));
+    }
+
+    @Test
+    public void testEqualsSameObject()
+    {
+        Optional<Integer> a = Optional.of(MAGIC);
+        assertTrue(a.equals(a));
+    }
+
+    @Test
+    public void testEqualsDifferentObjectSameValue()
+    {
+        Optional<Integer> a = Optional.of(MAGIC);
+        Optional<Integer> b = Optional.of(MAGIC);
+        assertTrue(a.equals(b));
+    }
+
+    @Test
+    public void testEqualsDifferentValues()
+    {
+        Optional<Integer> a = Optional.of(MAGIC);
+        Optional<Integer> b = Optional.of(MAGIC+1);
+        assertFalse(a.equals(b));
+    }
+
+    @Test
+    public void testEqualsNull()
+    {
+        Optional<Integer> a = Optional.of(MAGIC);
+        assertFalse(a.equals(null));
+    }
+
+    @Test
+    public void testEqualsDifferentTypes()
+    {
+        Optional<Integer> a = Optional.of(MAGIC);
+        Optional<Long> b = Optional.of((long)MAGIC);
+        assertFalse(a.equals(b));
+    }
+
+    @Test
+    public void testEqualsEmpty()
+    {
+        assertTrue(Optional.empty().equals(Optional.empty()));
+        assertFalse(Optional.empty().equals(Optional.of(MAGIC)));
+    }
+
+    @Test
+    public void testEqualsNonOption()
+    {
+        Optional<Integer> a = Optional.of(MAGIC);
+        assertFalse(a.equals(MAGIC));
+    }
+}

--- a/test/org/jitsi/impl/neomedia/stats/ConcurrentMultiKeyMapTest.java
+++ b/test/org/jitsi/impl/neomedia/stats/ConcurrentMultiKeyMapTest.java
@@ -1,0 +1,81 @@
+package org.jitsi.impl.neomedia.stats;
+
+import org.jitsi.impl.neomedia.java8.BiFunction;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class ConcurrentMultiKeyMapTest {
+
+    private static final Integer MAGIC = 0xd0b;
+    private static final Integer MAGIC_TWO = 0xd0bd0b;
+    private ConcurrentMultiKeyMap<Integer, Integer, Integer> map;
+
+    @Before
+    public void setup() {
+        map = new ConcurrentMultiKeyMap<>();
+    }
+
+    @Test
+    public void testGetSubmap() {
+        Map<Integer, Integer> subMap = map.get(0);
+        subMap.put(0, MAGIC);
+        assertEquals(MAGIC, map.get(0, 0));
+    }
+
+    @Test
+    public void testEmptyGet() {
+        assertEquals(null, map.get(0, 0));
+    }
+
+    @Test
+    public void testPutIfAbsent() {
+        Integer previous = map.putIfAbsent(0, 0, MAGIC);
+        assertEquals(null, previous);
+        putIfAbsentShouldNoopSecondCall();
+    }
+
+    private void putIfAbsentShouldNoopSecondCall() {
+        Integer previous = map.putIfAbsent(0, 0, MAGIC_TWO);
+        assertEquals(MAGIC, previous);
+    }
+
+    @Test
+    public void testGet() {
+        map.putIfAbsent(0, 0, MAGIC);
+        assertEquals(MAGIC, map.get(0, 0));
+    }
+
+    @Test
+    public void testGet2() {
+        map.putIfAbsent(1, 3, MAGIC);
+        map.putIfAbsent(7, 2, MAGIC_TWO);
+        assertEquals(MAGIC_TWO, map.get(7, 2));
+    }
+
+
+    @Test
+    public void testComputeIfAbsent() {
+        Integer value = map.computeIfAbsent(0, 0, new BiFunction<Integer, Integer, Integer>() {
+            @Override
+            public Integer apply(Integer var, Integer var2) {
+                return MAGIC;
+            }
+        });
+        assertEquals(MAGIC, value);
+        computeIfAbsentShouldNoopComputeForSecondCall();
+    }
+
+    private void computeIfAbsentShouldNoopComputeForSecondCall() {
+        Integer value = map.computeIfAbsent(0, 0, new BiFunction<Integer, Integer, Integer>() {
+            @Override
+            public Integer apply(Integer var, Integer var2) {
+                return MAGIC_TWO;
+            }
+        });
+        assertEquals(MAGIC, value);
+    }
+}

--- a/test/org/jitsi/impl/neomedia/stats/StatisticsTableTest.java
+++ b/test/org/jitsi/impl/neomedia/stats/StatisticsTableTest.java
@@ -1,0 +1,85 @@
+package org.jitsi.impl.neomedia.stats;
+
+import org.jitsi.impl.neomedia.java8.Optional;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class StatisticsTableTest {
+
+    private StatisticsTable table;
+    private long MAGIC_VALUE = 0xbaL;
+    private String COUNTER_NAME = "bababa";
+
+    @Before
+    public void setup()
+    {
+        table = new StatisticsTable();
+    }
+
+    @Test
+    public void testGetCreatesNewCounter()
+    {
+        Counter counter = table.get("");
+        assertEquals(0, counter.get());
+    }
+
+    @Test
+    public void testIdMultiGetCreatesNewCounter()
+    {
+        Counter counter = table.get(0, "");
+        assertEquals(0, counter.get());
+    }
+
+    @Test
+    public void testGetReturnsSameCounter()
+    {
+        Counter counter = table.get(0, "");
+        Counter counter2 = table.get(0, "");
+        assertTrue(counter == counter2);
+    }
+
+    @Test
+    public void testGetCounterWithId()
+    {
+        StatisticsTable.GetCounterWithStreamId getter = table.get(0);
+        Counter counter = getter.get(COUNTER_NAME);
+        assertEquals(0, counter.get());
+        assertTrue(counter == table.get(0, COUNTER_NAME));
+    }
+
+    @Test
+    public void testGetWithCounterNames()
+    {
+        Counter counter;
+        counter = table.get(CounterName.AVAILABLE_SEND_BANDWIDTH_BPS);
+        assertEquals(0, counter.get());
+
+        counter = table.get(0, CounterName.AVAILABLE_SEND_BANDWIDTH_BPS);
+        assertEquals(0, counter.get());
+
+        counter = table.get(0).get(CounterName.AVAILABLE_SEND_BANDWIDTH_BPS);
+        assertEquals(0, counter.get());
+    }
+
+    @Test
+    public void testWithKeyPrefixReturnsNamespacedTable()
+    {
+        Counter counter = table.get(0, "hello.jo");
+        Counter counter2 = table.withKeyPrefix("hello").get(0, "jo");
+        assertTrue(counter == counter2);
+    }
+
+    @Test
+    public void testToMapContainsMapContents()
+    {
+        table.get(0, COUNTER_NAME).set(MAGIC_VALUE);
+        Map<StatisticsTable.Key, Long> map = table.toMap();
+        Long count = map.get(new StatisticsTable.Key(Optional.of(0L), COUNTER_NAME));
+        assertEquals(MAGIC_VALUE, count.longValue());
+    }
+}

--- a/test/org/jitsi/impl/neomedia/stats/StatisticsTableTest.java
+++ b/test/org/jitsi/impl/neomedia/stats/StatisticsTableTest.java
@@ -79,7 +79,7 @@ public class StatisticsTableTest {
     {
         table.get(0, COUNTER_NAME).set(MAGIC_VALUE);
         Map<StatisticsTable.Key, Long> map = table.toMap();
-        Long count = map.get(new StatisticsTable.Key(Optional.of(0L), COUNTER_NAME));
+        Long count = map.get(new StatisticsTable.Key(Optional.of(0), COUNTER_NAME));
         assertEquals(MAGIC_VALUE, count.longValue());
     }
 }


### PR DESCRIPTION
Created a mechanism to allow the flexible creation of counters to record the behavior of the bitrate estimators.

Not sure if you want this, but having a way to quickly instrument the rate controller with counters made it much easier to track down the rate control problem outlined in: https://github.com/jitsi/libjitsi/pull/239

