### PR TITLE
Add org.jitsi.impl.neomedia.RawPacket.DISCARD_CONTRIBUTING_SOURCES config property

### DIFF
--- a/src/org/jitsi/impl/neomedia/RawPacket.java
+++ b/src/org/jitsi/impl/neomedia/RawPacket.java
@@ -15,6 +15,10 @@
  */
 package org.jitsi.impl.neomedia;
 
+import org.jitsi.service.configuration.*;
+import org.jitsi.service.libjitsi.*;
+import org.jitsi.service.neomedia.*;
+import org.jitsi.util.*;
 
 import org.jitsi.service.neomedia.*;
 
@@ -77,6 +81,30 @@ public class RawPacket
      * RTPManager we store this info. (Not assuming the offset is always zero)
      */
     private int offset;
+
+    /**
+     * The flag that determines whether the list of CSRC identifiers are to be
+     * discarded in all packets. The CSRC count will be 0 as well. The default
+     * value is <tt>false</tt>.
+     */
+    private static final boolean discardCSRC;
+
+    /**
+     * The name of the <tt>ConfigurationService</tt> and/or <tt>System</tt>
+     * property which indicates whether the list of CSRC identifiers are to
+     * be discarded from all packets. The default value is <tt>false</tt>.
+     */
+    private static final String DISCARD_CONTRIBUTING_SOURCES_PNAME
+        = RawPacket.class.getName() + ".DISCARD_CONTRIBUTING_SOURCES";
+
+    static
+    {
+        ConfigurationService cfg = LibJitsi.getConfigurationService();
+
+        DISCARD_CONTRIBUTING_SOURCES
+            = ConfigUtils.getBoolean(cfg, DISCARD_CONTRIBUTING_SOURCES_PNAME,
+                false);
+    }
 
     /**
      * Initializes a new empty <tt>RawPacket</tt> instance.
@@ -1285,6 +1313,9 @@ public class RawPacket
      */
     public void setCsrcList(long[] newCsrcList)
     {
+        if(this.discardCSRC)
+            return;
+
         int newCsrcCount = newCsrcList.length;
         byte[] csrcBuff = new byte[newCsrcCount * 4];
         int csrcOffset = 0;

--- a/src/org/jitsi/impl/neomedia/RawPacket.java
+++ b/src/org/jitsi/impl/neomedia/RawPacket.java
@@ -15,10 +15,6 @@
  */
 package org.jitsi.impl.neomedia;
 
-import org.jitsi.service.configuration.*;
-import org.jitsi.service.libjitsi.*;
-import org.jitsi.service.neomedia.*;
-import org.jitsi.util.*;
 
 import org.jitsi.service.neomedia.*;
 
@@ -83,30 +79,6 @@ public class RawPacket
     private int offset;
 
     /**
-     * The flag that determines whether the list of CSRC identifiers are to be
-     * discarded in all packets. The CSRC count will be 0 as well. The default
-     * value is <tt>false</tt>.
-     */
-    private static final boolean discardCSRC;
-
-    /**
-     * The name of the <tt>ConfigurationService</tt> and/or <tt>System</tt>
-     * property which indicates whether the list of CSRC identifiers are to
-     * be discarded from all packets. The default value is <tt>false</tt>.
-     */
-    private static final String DISCARD_CONTRIBUTING_SOURCES_PNAME
-        = RawPacket.class.getName() + ".DISCARD_CONTRIBUTING_SOURCES";
-
-    static
-    {
-        ConfigurationService cfg = LibJitsi.getConfigurationService();
-
-        DISCARD_CONTRIBUTING_SOURCES
-            = ConfigUtils.getBoolean(cfg, DISCARD_CONTRIBUTING_SOURCES_PNAME,
-                false);
-    }
-
-    /**
      * Initializes a new empty <tt>RawPacket</tt> instance.
      */
     public RawPacket()
@@ -118,7 +90,7 @@ public class RawPacket
      * <tt>byte</tt> array buffer.
      *
      * @param buffer the <tt>byte</tt> array to be the buffer of the new
-     * instance 
+     * instance
      * @param offset the offset in <tt>buffer</tt> at which the actual data to
      * be represented by the new instance starts
      * @param length the number of <tt>byte</tt>s in <tt>buffer</tt> which
@@ -1313,9 +1285,6 @@ public class RawPacket
      */
     public void setCsrcList(long[] newCsrcList)
     {
-        if(this.discardCSRC)
-            return;
-
         int newCsrcCount = newCsrcList.length;
         byte[] csrcBuff = new byte[newCsrcCount * 4];
         int csrcOffset = 0;

--- a/src/org/jitsi/impl/neomedia/transform/csrc/CsrcTransformEngine.java
+++ b/src/org/jitsi/impl/neomedia/transform/csrc/CsrcTransformEngine.java
@@ -20,7 +20,10 @@ import java.util.*;
 import net.sf.fmj.media.rtp.*;
 import org.jitsi.impl.neomedia.*;
 import org.jitsi.impl.neomedia.transform.*;
+import org.jitsi.service.configuration.*;
+import org.jitsi.service.libjitsi.*;
 import org.jitsi.service.neomedia.*;
+import org.jitsi.util.*;
 
 /**
  * We use this engine to add the list of CSRC identifiers in RTP packets that
@@ -66,6 +69,29 @@ public class CsrcTransformEngine
      * transform packets for.
      */
     private final MediaStreamImpl mediaStream;
+
+    /**
+    * The flag that determines whether the list of CSRC identifiers are to be
+    * discarded in all packets. The CSRC count will be 0 as well. The default
+    * value is <tt>false</tt>.
+    */
+   private static final boolean discardContributingSrcs;
+
+   /**
+    * The name of the <tt>ConfigurationService</tt> and/or <tt>System</tt>
+    * property which indicates whether the list of CSRC identifiers are to
+    * be discarded from all packets. The default value is <tt>false</tt>.
+    */
+   private static final String DISCARD_CONTRIBUTING_SRCS_PNAME
+       = CsrcTransformEngine.class.getName() + ".DISCARD_CONTRIBUTING_SOURCES";
+
+   static
+   {
+       ConfigurationService cfg = LibJitsi.getConfigurationService();
+
+       discardContributingSrcs =
+           ConfigUtils.getBoolean(cfg, DISCARD_CONTRIBUTING_SRCS_PNAME,false);
+   }
 
     /**
      * Creates an engine instance that will be adding CSRC lists to the
@@ -284,7 +310,7 @@ public class CsrcTransformEngine
 
         long[] csrcList = mediaStream.getLocalContributingSourceIDs();
 
-        if(csrcList == null || csrcList.length == 0)
+        if(csrcList == null || csrcList.length == 0 || this.discardContributingSrcs)
         {
             //nothing to do.
             return pkt;


### PR DESCRIPTION
This property is useful when a SIP Provider does not support the list of contributing sources in its SIP infrastructure. If one is having annoying noise issues, this property may solve it when it is set to true.