### PR TITLE
fix: Don't count packets which failed to retransmit.

### DIFF
--- a/src/org/jitsi/impl/neomedia/transform/RtxTransformer.java
+++ b/src/org/jitsi/impl/neomedia/transform/RtxTransformer.java
@@ -657,8 +657,10 @@ public class RtxTransformer
                     int len = container.pkt.getLength();
                     if (bytes - len > 0)
                     {
-                        retransmit(container.pkt, this);
-                        bytes -= len;
+                        if (retransmit(container.pkt, this))
+                        {
+                            bytes -= len;
+                        }
                     }
                     else
                     {


### PR DESCRIPTION
I see a "failed to retransmit"  message being logged, and while I don't know what the reason is, it seems to make sense to not count them towards the retransmitted bytes.