### PR TITLE
Fixes around adaptivity RTP stream shaping

### DIFF
--- a/src/org/jitsi/impl/neomedia/rtp/FrameDesc.java
+++ b/src/org/jitsi/impl/neomedia/rtp/FrameDesc.java
@@ -269,6 +269,7 @@ public class FrameDesc
                 {
                     logger.info("keyframe,stream=" + stream.hashCode()
                         + " ssrc=" + rtpEncoding.getPrimarySSRC()
+                        + ",idx=" + rtpEncoding.getIndex()
                         + "," + toString());
                 }
             }

--- a/src/org/jitsi/impl/neomedia/rtp/FrameDesc.java
+++ b/src/org/jitsi/impl/neomedia/rtp/FrameDesc.java
@@ -130,7 +130,7 @@ public class FrameDesc
      *
      * @return the end sequence number for this source frame.
      */
-    int getEnd()
+    public int getEnd()
     {
         return end;
     }

--- a/src/org/jitsi/impl/neomedia/rtp/RTPEncodingDesc.java
+++ b/src/org/jitsi/impl/neomedia/rtp/RTPEncodingDesc.java
@@ -603,7 +603,7 @@ public class RTPEncodingDesc
      *
      * @return the {@link RTPEncodingDesc} on which this layer depends.
      */
-    RTPEncodingDesc[] getDependencyEncodings()
+    public RTPEncodingDesc[] getDependencyEncodings()
     {
         return dependencyEncodings;
     }

--- a/src/org/jitsi/impl/neomedia/rtp/translator/BitstreamController.java
+++ b/src/org/jitsi/impl/neomedia/rtp/translator/BitstreamController.java
@@ -15,7 +15,6 @@
  */
 package org.jitsi.impl.neomedia.rtp.translator;
 
-import net.sf.fmj.media.rtp.*;
 import org.jitsi.impl.neomedia.rtcp.*;
 import org.jitsi.impl.neomedia.rtp.*;
 import org.jitsi.service.neomedia.*;
@@ -99,36 +98,32 @@ public class BitstreamController
 
     /**
      * Ctor. Used when switching between independent bitstreams
-     * (simulcast case).
+     * (simulcast case). This ctor maintains the old targets and optimal
+     * indices.
      *
      * @param bc the previous {@link BitstreamController}.
-     * @param currentTL0Idx the TL0 of the current bitstream.
+     * @param tl0Idx the TL0 of the RTP stream that this controller filters
+     * traffic from.
      */
-    BitstreamController(BitstreamController bc, int currentTL0Idx)
+    BitstreamController(BitstreamController bc, int tl0Idx)
     {
         this(bc.weakSource, bc.getMaxSeqNum(), bc.getMaxTs(),
             bc.transmittedBytes, bc.transmittedPackets,
-            currentTL0Idx, bc.targetIdx, bc.optimalIdx);
+            tl0Idx, bc.targetIdx, bc.optimalIdx);
     }
 
     /**
-     * Ctor.
+     * Ctor. The ctor sets all of the indices to -1.
      *
      * @param source the source {@link MediaStreamTrackDesc} for this instance.
-     * @param currentIdx the current subjective quality index for this instance.
-     * @param targetIdx the target subjective quality index for this instance.
-     * @param optimalIdx the optimal subjective quality index for this instance.
      */
-    BitstreamController(
-        MediaStreamTrackDesc source,
-        int currentIdx, int targetIdx, int optimalIdx)
+    BitstreamController(MediaStreamTrackDesc source)
     {
-        this(new WeakReference<>(source),
-            -1, -1, 0, 0, currentIdx, targetIdx, optimalIdx);
+        this(new WeakReference<>(source), -1, -1, 0, 0, -1, -1, -1);
     }
 
     /**
-     * Ctor.
+     * A private ctor that initializes all the fields of this instance.
      *
      * @param weakSource a weak reference to the source
      * {@link MediaStreamTrackDesc} for this instance.
@@ -140,7 +135,8 @@ public class BitstreamController
      * this instance sends will be added to this value).
      * @param transmittedPacketsOff the transmitted packets offset (the packets
      * that this instance sends will be added to this value).
-     * @param currentIdx the current subjective quality index for this instance.
+     * @param tl0Idx the TL0 of the RTP stream that this controller filters
+     * traffic from.
      * @param targetIdx the target subjective quality index for this instance.
      * @param optimalIdx the optimal subjective quality index for this instance.
      */
@@ -148,13 +144,15 @@ public class BitstreamController
         WeakReference<MediaStreamTrackDesc> weakSource,
         int seqNumOff, long tsOff,
         long transmittedBytesOff, long transmittedPacketsOff,
-        int currentIdx, int targetIdx, int optimalIdx)
+        int tl0Idx, int targetIdx, int optimalIdx)
     {
         this.seqNumOff = seqNumOff;
         this.tsOff = tsOff;
         this.transmittedBytes = transmittedBytesOff;
         this.transmittedPackets = transmittedPacketsOff;
         this.optimalIdx = optimalIdx;
+        this.targetIdx = targetIdx;
+        this.currentIdx = -1;
         this.weakSource = weakSource;
 
         MediaStreamTrackDesc source = weakSource.get();
@@ -167,11 +165,9 @@ public class BitstreamController
         }
         else
         {
-            int currentTL0Idx = currentIdx;
-            if (currentIdx > -1)
+            if (tl0Idx > -1)
             {
-                currentTL0Idx
-                    = rtpEncodings[currentTL0Idx].getBaseLayer().getIndex();
+                tl0Idx = rtpEncodings[tl0Idx].getBaseLayer().getIndex();
             }
 
             // find the available qualities in this bitstream.
@@ -180,7 +176,7 @@ public class BitstreamController
             List<Integer> availableQualities = new ArrayList<>();
             for (int i = 0; i < rtpEncodings.length; i++)
             {
-                if (rtpEncodings[i].requires(currentTL0Idx))
+                if (rtpEncodings[i].requires(tl0Idx))
                 {
                     availableQualities.add(i);
                 }
@@ -193,17 +189,15 @@ public class BitstreamController
                 availableIdx[i] = iterator.next();
             }
 
-            if (currentTL0Idx > -1)
+            if (tl0Idx > -1)
             {
-                tl0SSRC = rtpEncodings[currentTL0Idx].getPrimarySSRC();
+                tl0SSRC = rtpEncodings[tl0Idx].getPrimarySSRC();
             }
             else
             {
                 tl0SSRC = -1;
             }
         }
-
-        setTargetIndex(targetIdx);
     }
 
     /**
@@ -244,6 +238,24 @@ public class BitstreamController
             // key frame.
 
             int currentIdx = this.currentIdx;
+
+            if (availableIdx != null && availableIdx.length != 0)
+            {
+                currentIdx = availableIdx[0];
+                for (int i = 1; i < availableIdx.length; i++)
+                {
+                    if (availableIdx[i] <= targetIdx)
+                    {
+                        currentIdx = availableIdx[i];
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+
+                this.currentIdx = currentIdx;
+            }
 
             if (currentIdx >= 0 && (maxSentFrame == null
                 || TimeUtils.rtpDiff(srcTs, maxSentFrame.srcTs) > 0))
@@ -380,28 +392,6 @@ public class BitstreamController
     void setTargetIndex(int newTargetIdx)
     {
         this.targetIdx = newTargetIdx;
-        if (newTargetIdx < 0)
-        {
-            // suspend the stream
-            currentIdx = newTargetIdx;
-        }
-        else if (availableIdx != null && availableIdx.length != 0)
-        {
-            int currentIdx = availableIdx[0];
-            for (int i = 1; i < availableIdx.length; i++)
-            {
-                if (availableIdx[i] <= targetIdx)
-                {
-                    currentIdx = availableIdx[i];
-                }
-                else
-                {
-                    break;
-                }
-            }
-
-            this.currentIdx = currentIdx;
-        }
     }
 
     /**
@@ -426,6 +416,11 @@ public class BitstreamController
      */
     RawPacket[] rtpTransform(RawPacket pktIn)
     {
+        if (pktIn.getSSRCAsLong() != tl0SSRC)
+        {
+            return null;
+        }
+
         SeenFrame destFrame = seenFrames.get(pktIn.getTimestamp());
         if (destFrame == null)
         {

--- a/src/org/jitsi/impl/neomedia/rtp/translator/BitstreamController.java
+++ b/src/org/jitsi/impl/neomedia/rtp/translator/BitstreamController.java
@@ -152,6 +152,7 @@ public class BitstreamController
         this.transmittedPackets = transmittedPacketsOff;
         this.optimalIdx = optimalIdx;
         this.targetIdx = targetIdx;
+        // a stream always starts suspended (and resumes with a key frame).
         this.currentIdx = -1;
         this.weakSource = weakSource;
 


### PR DESCRIPTION
The two major changes are  1st the fact that we now use a separate `BitstreamController` when a stream is suspended (when a receiver doesn't have enough bandwidth). This allows us to treat suspension/resumption the same way as a simulcast layer switch, removing unnecessary complexity from the BitstreamController that shapes an RTP stream and 2nd how we update the target quality index.
