### PR TITLE
Do not forward nack

### DIFF
--- a/src/org/jitsi/impl/neomedia/rtcp/RTCPReceiverFeedbackTermination.java
+++ b/src/org/jitsi/impl/neomedia/rtcp/RTCPReceiverFeedbackTermination.java
@@ -375,7 +375,7 @@ public class RTCPReceiverFeedbackTermination
         public RawPacket transform(RawPacket pkt)
         {
             // Kill RRs.
-            return reverseTransform(pkt);
+            return doTransform(pkt);
         }
 
         /**
@@ -383,6 +383,11 @@ public class RTCPReceiverFeedbackTermination
          */
         @Override
         public RawPacket reverseTransform(RawPacket pkt)
+        {
+            return doTransform(pkt);
+        }
+
+        private RawPacket doTransform(RawPacket pkt)
         {
             RTCPIterator it = new RTCPIterator(pkt);
             while (it.hasNext())

--- a/src/org/jitsi/impl/neomedia/transform/RtxTransformer.java
+++ b/src/org/jitsi/impl/neomedia/transform/RtxTransformer.java
@@ -493,7 +493,7 @@ public class RtxTransformer
             }
         }
 
-        if (!lostPackets.isEmpty())
+        if (!lostPackets.isEmpty() && logger.isDebugEnabled())
         {
             // If retransmission requests are enabled, videobridge assumes
             // the responsibility of requesting missing packets.
@@ -705,6 +705,7 @@ public class RtxTransformer
                         = NACKPacket.getLostPackets(next);
                     long mediaSSRC = NACKPacket.getSourceSSRC(next);
                     nackReceived(mediaSSRC, lostPackets);
+                    it.remove();
                 }
             }
 

--- a/src/org/jitsi/impl/neomedia/transform/rtcp/StatisticsEngine.java
+++ b/src/org/jitsi/impl/neomedia/transform/rtcp/StatisticsEngine.java
@@ -1014,6 +1014,8 @@ public class StatisticsEngine
             case RTCPFBPacket.RTPFB:
                 if (rtcp instanceof NACKPacket)
                 {
+                    // NACKs are currently handled in RtxTransformer and do not
+                    // reach the StatisticsEngine.
                     NACKPacket nack = (NACKPacket) rtcp;
 
                     streamStats.nackReceived(nack);


### PR DESCRIPTION
NACKs should be consumed by the re-transmission logic and not forwarded to senders