### PR TITLE
Fix lgtm.com alert: unintentional comparison using '==' operator only tests for reference equality

### DIFF
--- a/src/org/jitsi/util/RTPUtils.java
+++ b/src/org/jitsi/util/RTPUtils.java
@@ -196,7 +196,7 @@ public class RTPUtils
         @Override
         public int compare(Integer a, Integer b)
         {
-            if (a == b)
+            if (a == b || a.intValue() == b.intValue())
             {
                 return 0;
             }


### PR DESCRIPTION
The comparison using the '==' operator /only/ checks for reference equality of the Integers, which is very likely not what was intended here. This PR adds a check for value equality by unboxing.

More alerts here: https://lgtm.com/projects/g/jitsi/libjitsi/
Link to this specific alert: https://lgtm.com/projects/g/jitsi/libjitsi/snapshot/3d13c1d8472e4f03be224dc3343ee25d817a26fd/files/src/org/jitsi/util/RTPUtils.java#L199

Tip: enable PR integration on lgtm.com for automatic code reviews. They'll catch this sort of problem before it gets merged.