### PR TITLE
feat: Adds the RtxTransformer.destinationSupportsRtx() method.

### DIFF
--- a/src/org/jitsi/impl/neomedia/transform/RtxTransformer.java
+++ b/src/org/jitsi/impl/neomedia/transform/RtxTransformer.java
@@ -141,6 +141,17 @@ public class RtxTransformer
     }
 
     /**
+     * Returns a boolean that indicates whether or not the destination
+     * endpoint supports RTX.
+     *
+     * @return true if the destination endpoint supports RTX, otherwise false.
+     */
+    public boolean destinationSupportsRtx()
+    {
+        return !apt2rtx.isEmpty();
+    }
+
+    /**
      * Returns the sequence number to use for a specific RTX packet, which
      * is based on the packet's original sequence number.
      *
@@ -210,6 +221,7 @@ public class RtxTransformer
 
         return encoding.getRTXSSRC();
     }
+
     /**
      * Retransmits a packet to {@link #mediaStream}. If the destination supports
      * the RTX format, the packet will be encapsulated in RTX, otherwise, the


### PR DESCRIPTION
Currently the FF webrtc engine ignores our bandwidth probing (https://bugzilla.mozilla.org/show_bug.cgi?id=1362450), so we want to disable bandwidth probing for FF. FF also does not support RTX. This method will be used by the bridge to determine whether the destination endpoint has RTX or not. If not, then that would indicate a FF destination endpoint and it will disable adaptivity for that endpoint.