### PR TITLE
Zero length rtcp fix

### DIFF
--- a/src/org/jitsi/impl/neomedia/rtcp/RTCPReceiverFeedbackTermination.java
+++ b/src/org/jitsi/impl/neomedia/rtcp/RTCPReceiverFeedbackTermination.java
@@ -418,7 +418,7 @@ public class RTCPReceiverFeedbackTermination
                     }
                 }
             }
-            return pkt;
+            return pkt.getLength() == 0 ? null : pkt;
         }
     }
 }

--- a/src/org/jitsi/impl/neomedia/rtp/MediaStreamTrackDesc.java
+++ b/src/org/jitsi/impl/neomedia/rtp/MediaStreamTrackDesc.java
@@ -436,33 +436,6 @@ public class MediaStreamTrackDesc
     }
 
     /**
-     * Gets the maximum subjective quality index that complies to the max height
-     * specified as an argument.
-     *
-     * @param maxHeight the max height
-     * @return the maximum subjective quality index that complies to the max
-     * height specified as an argument, or -1 if no encoding meets the maxHeight
-     * that is specified as an argument..
-     */
-    public int getMaxIndex(int maxHeight)
-    {
-        int optimalIndex = -1;
-
-        if (!ArrayUtils.isNullOrEmpty(rtpEncodings))
-        {
-            for (int i = 0; i < rtpEncodings.length; i++)
-            {
-                if (rtpEncodings[i].getHeight() <= maxHeight)
-                {
-                    optimalIndex = i;
-                }
-            }
-        }
-
-        return optimalIndex;
-    }
-
-    /**
      * Stats for {@link MediaStreamTrackDesc} instances.
      */
     public static class Statistics


### PR DESCRIPTION
Zero length packets can make our SRTP stack to crash, so instead of
letting them through, return null.