### PR TITLE
Retrieve Spatial and Temporal layer ids from frame marking header extension

### DIFF
--- a/src/org/jitsi/impl/neomedia/MediaStreamImpl.java
+++ b/src/org/jitsi/impl/neomedia/MediaStreamImpl.java
@@ -3787,12 +3787,6 @@ public class MediaStreamImpl
             {
                 return FrameMarkingHeaderExtension.isStartOfFrame(fmhe);
             }
-
-            if (logger.isDebugEnabled())
-            {
-                logger.debug("Packet with no frame marking, while frame marking"
-                             + " is enabled.");
-            }
             // Note that we go on and try to use the payload itself. We may want
             // to change this behaviour in the future, because it will give
             // wrong results if the payload is encrypted.
@@ -3857,12 +3851,6 @@ public class MediaStreamImpl
             if (fmhe != null)
             {
                 return FrameMarkingHeaderExtension.isEndOfFrame(fmhe);
-            }
-
-            if (logger.isDebugEnabled())
-            {
-                logger.debug("Packet with no frame marking, while frame marking"
-                             + " is enabled.");
             }
             // Note that we go on and try to use the payload itself. We may want
             // to change this behaviour in the future, because it will give

--- a/src/org/jitsi/impl/neomedia/MediaStreamImpl.java
+++ b/src/org/jitsi/impl/neomedia/MediaStreamImpl.java
@@ -3653,6 +3653,21 @@ public class MediaStreamImpl
      */
     public int getTemporalID(byte[] buf, int off, int len)
     {
+        if (frameMarkingsExtensionId != -1)
+        {
+            RawPacket pkt = new RawPacket(buf, off, len);
+            RawPacket.HeaderExtension fmhe
+                = pkt.getHeaderExtension(frameMarkingsExtensionId);
+
+            if (fmhe != null)
+            {
+                return FrameMarkingHeaderExtension.getTemporalID(fmhe);
+            }
+            // Note that we go on and try to use the payload itself. We may want
+            // to change this behaviour in the future, because it will give
+            // wrong results if the payload is encrypted.
+        }
+    
         REDBlock redBlock = getPayloadBlock(buf, off, len);
         if (redBlock == null || redBlock.getLength() == 0)
         {
@@ -3702,6 +3717,21 @@ public class MediaStreamImpl
      */
     public int getSpatialID(byte[] buf, int off, int len)
     {
+        if (frameMarkingsExtensionId != -1) 
+	{
+            RawPacket pkt = new RawPacket(buf, off, len);
+	    String encoding = getFormat(pkt.getPayloadType()).getEncoding();
+            RawPacket.HeaderExtension fmhe
+                = pkt.getHeaderExtension(frameMarkingsExtensionId);
+            if (fmhe != null)
+            {
+                return FrameMarkingHeaderExtension.getSpatialID(fmhe,encoding);
+            }
+            // Note that we go on and try to use the payload itself. We may want
+            // to change this behaviour in the future, because it will give
+            // wrong results if the payload is encrypted.
+        }
+
         REDBlock redBlock = getPayloadBlock(buf, off, len);
         if (redBlock == null || redBlock.getLength() == 0)
         {
@@ -3891,12 +3921,6 @@ public class MediaStreamImpl
             if (fmhe != null)
             {
                 return FrameMarkingHeaderExtension.isKeyframe(fmhe);
-            }
-
-            if (logger.isDebugEnabled())
-            {
-                logger.debug("Packet with no frame marking, while frame marking"
-                             + " is enabled.");
             }
             // Note that we go on and try to use the payload itself. We may want
             // to change this behaviour in the future, because it will give

--- a/src/org/jitsi/impl/neomedia/rtp/FrameMarkingHeaderExtension.java
+++ b/src/org/jitsi/impl/neomedia/rtp/FrameMarkingHeaderExtension.java
@@ -21,6 +21,7 @@ import org.jitsi.service.neomedia.*;
  * Provides utility functions for the frame marking RTP header extension
  * described in https://tools.ietf.org/html/draft-ietf-avtext-framemarking-03
  *
+ * Non-Scalable
  * <pre>{@code
  *  0                   1
  *  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5
@@ -28,7 +29,15 @@ import org.jitsi.service.neomedia.*;
  * |  ID=? |  L=0  |S|E|I|D|0 0 0 0|
  * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
  * }</pre>
- *
+ * 
+ * Scalable
+ * <pre>{@code
+ *  0                   1                   2                   3
+ *  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |  ID=? |  L=2  |S|E|I|D|B| TID |   LID         |    TL0PICIDX  |
+ *  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * }</pre>
  * @author Boris Grozev
  * @author Sergio Garcia Murillo
  */
@@ -54,6 +63,11 @@ public class FrameMarkingHeaderExtension
      * first packet of a keyframe.
      */
     private static byte KF_MASK = (byte) (S_BIT | I_BIT);
+    
+    /**
+     * The bits for the temporalId 
+     */
+    private static byte TID_MASK = (byte) 0x07;
 
     /**
      * @return true if the extension contained in the given buffer indicates
@@ -104,5 +118,27 @@ public class FrameMarkingHeaderExtension
         // The data follows the one-byte header.
         byte b = baf.getBuffer()[baf.getOffset() + 1];
         return (b & E_BIT) != 0;
+    }
+
+    public static byte getSpatialID(ByteArrayBuffer baf, String encoding) {
+        // Only present on scalable version
+        if (baf == null || baf.getLength() < 4)
+        {
+            return 0;
+        }
+        /*
+         * THIS IS STILL NOT YET CORRECTLY DEFINED ON FRAMEMARKING DRAFT!
+         */
+        return 0;
+    }
+
+    public static byte getTemporalID(ByteArrayBuffer baf) {
+        if (baf == null || baf.getLength() < 2)
+        {
+            return 0;
+        }
+        // The data follows the one-byte header.
+        byte b = baf.getBuffer()[baf.getOffset() + 1];
+        return (byte)(b & TID_MASK);
     }
 }

--- a/src/org/jitsi/impl/neomedia/rtp/FrameMarkingHeaderExtension.java
+++ b/src/org/jitsi/impl/neomedia/rtp/FrameMarkingHeaderExtension.java
@@ -120,6 +120,12 @@ public class FrameMarkingHeaderExtension
         return (b & E_BIT) != 0;
     }
 
+    /**
+     * 
+     * @param baf Header extension byte array
+     * @param encoding Encoding type used to parse the LID field
+     * @return the spatial layerd id present in the LID or 0 if not present. 
+     */
     public static byte getSpatialID(ByteArrayBuffer baf, String encoding) {
         // Only present on scalable version
         if (baf == null || baf.getLength() < 4)
@@ -132,6 +138,11 @@ public class FrameMarkingHeaderExtension
         return 0;
     }
 
+    /**
+     * 
+     * @param baf Header extension byte array
+     * @return The temporal layer id (the LID bits) or 0 if not present
+     */
     public static byte getTemporalID(ByteArrayBuffer baf) {
         if (baf == null || baf.getLength() < 2)
         {


### PR DESCRIPTION
The patch was going to be more ambitious as IMHO the RawPacket should be passed from the top layers instead of buff,off,len ... but it was not working so I decided to go KISS first

In order to have simulcast enabled with media encryption it is required to disable the vp8 extended pic id on videobridge:
```
org.jitsi.videobridge.ENABLE_VP8_PICID_REWRITING=false
```

cc/ @bgrozev 
