### PR TITLE
Fix FMJ codec registration when FFMpeg is enabled

### DIFF
--- a/src/org/jitsi/impl/neomedia/codec/FMJPlugInConfiguration.java
+++ b/src/org/jitsi/impl/neomedia/codec/FMJPlugInConfiguration.java
@@ -214,7 +214,8 @@ public class FMJPlugInConfiguration
                 "net.sf.fmj.media.codec.JavaSoundCodec",
                 PlugInManager.CODEC);
 
-        List<String> customCodecs = Arrays.asList(CUSTOM_CODECS);
+        List<String> customCodecs = new LinkedList<>();
+        customCodecs.addAll(Arrays.asList(CUSTOM_CODECS));
         if (enableFfmpeg)
         {
             customCodecs.addAll(Arrays.asList(CUSTOM_CODECS_FFMPEG));


### PR DESCRIPTION
Arrays.asList creates a List<> that is backed by the original array. It doesn't accept adding elements, thus adding the FFMpeg codecs would later fail. Fix this by using a regular list.