### PR TITLE
add 'isOlderSequenceNumberThan' and 'applySequenceNumberDelta' helper…

### DIFF
--- a/src/org/jitsi/impl/neomedia/rtcp/RTCPTCCPacket.java
+++ b/src/org/jitsi/impl/neomedia/rtcp/RTCPTCCPacket.java
@@ -19,7 +19,6 @@ import net.sf.fmj.media.rtp.*;
 import org.jitsi.service.neomedia.*;
 import org.jitsi.util.*;
 
-import java.io.*;
 import java.util.*;
 
 /**
@@ -470,7 +469,7 @@ public class RTCPTCCPacket
         int firstSeq = first.getKey();
         Map.Entry<Integer, Long> last = packets.lastEntry();
         int packetCount
-            = 1 + RTPUtils.sequenceNumberDiff(last.getKey(), firstSeq);
+            = 1 + RTPUtils.getSequenceNumberDelta(last.getKey(), firstSeq);
 
         // Temporary buffer to store the fixed fields (8 bytes) and the list of
         // packet status chunks (see the format above). The buffer may be longer

--- a/src/org/jitsi/impl/neomedia/rtp/FrameDesc.java
+++ b/src/org/jitsi/impl/neomedia/rtp/FrameDesc.java
@@ -266,8 +266,8 @@ public class FrameDesc
         }
 
         int seqNum = pkt.getSequenceNumber();
-        return RTPUtils.sequenceNumberDiff(seqNum, minSeen) >= 0
-            && RTPUtils.sequenceNumberDiff(seqNum, maxSeen) <= 0;
+        return RTPUtils.getSequenceNumberDelta(seqNum, minSeen) >= 0
+            && RTPUtils.getSequenceNumberDelta(seqNum, maxSeen) <= 0;
     }
 
 
@@ -287,13 +287,13 @@ public class FrameDesc
         MediaStreamImpl stream = rtpEncoding.getMediaStreamTrack()
             .getMediaStreamTrackReceiver().getStream();
 
-        if (minSeen == -1 || RTPUtils.sequenceNumberDiff(minSeen, seqNum) > 0)
+        if (minSeen == -1 || RTPUtils.getSequenceNumberDelta(minSeen, seqNum) > 0)
         {
             changed = true;
             minSeen = seqNum;
         }
 
-        if (maxSeen == -1 || RTPUtils.sequenceNumberDiff(maxSeen, seqNum) < 0)
+        if (maxSeen == -1 || RTPUtils.getSequenceNumberDelta(maxSeen, seqNum) < 0)
         {
             changed = true;
             maxSeen = seqNum;

--- a/src/org/jitsi/impl/neomedia/rtp/RTPEncodingDesc.java
+++ b/src/org/jitsi/impl/neomedia/rtp/RTPEncodingDesc.java
@@ -278,7 +278,7 @@ public class RTPEncodingDesc
         int lowestSeenSeqNumOfNewerFrame = newerFrame.getMinSeen();
         int highestSeenSeqNumOfOlderFrame = olderFrame.getMaxSeen();
         int seqNumDiff =
-                RTPUtils.sequenceNumberDiff(lowestSeenSeqNumOfNewerFrame, highestSeenSeqNumOfOlderFrame);
+                RTPUtils.getSequenceNumberDelta(lowestSeenSeqNumOfNewerFrame, highestSeenSeqNumOfOlderFrame);
 
         boolean guessed = false;
 

--- a/src/org/jitsi/impl/neomedia/rtp/ResumableStreamRewriter.java
+++ b/src/org/jitsi/impl/neomedia/rtp/ResumableStreamRewriter.java
@@ -141,7 +141,7 @@ public class ResumableStreamRewriter
                 = RTPUtils.subtractNumber(sequenceNumber, seqnumDelta);
 
             // init or update the highest sent sequence number (if needed)
-            if (highestSequenceNumberSent == -1 || RTPUtils.sequenceNumberDiff(
+            if (highestSequenceNumberSent == -1 || RTPUtils.getSequenceNumberDelta(
                 newSequenceNumber, highestSequenceNumberSent) > 0)
             {
                 highestSequenceNumberSent = newSequenceNumber;
@@ -157,7 +157,7 @@ public class ResumableStreamRewriter
                 final int newDelta = RTPUtils.subtractNumber(
                     sequenceNumber, highestSequenceNumberSent);
 
-                if (RTPUtils.sequenceNumberDiff(newDelta, seqnumDelta) > 0)
+                if (RTPUtils.getSequenceNumberDelta(newDelta, seqnumDelta) > 0)
                 {
                     seqnumDelta = newDelta;
                 }

--- a/src/org/jitsi/impl/neomedia/stats/ReceiveTrackStatsImpl.java
+++ b/src/org/jitsi/impl/neomedia/stats/ReceiveTrackStatsImpl.java
@@ -88,7 +88,7 @@ public class ReceiveTrackStatsImpl
         }
 
         // Now check for lost packets.
-        int diff = RTPUtils.sequenceNumberDiff(seq, highestSeq);
+        int diff = RTPUtils.getSequenceNumberDelta(seq, highestSeq);
         if (diff <= 0)
         {
             // RFC3550 says that all packets should be counted as received.

--- a/src/org/jitsi/impl/neomedia/stats/SendTrackStatsImpl.java
+++ b/src/org/jitsi/impl/neomedia/stats/SendTrackStatsImpl.java
@@ -85,7 +85,7 @@ public class SendTrackStatsImpl
         // locally), as is the case in jitsi-videobridge, packets may be lost
         // between the sender and us, and we need to take this into account
         // when calculating packet loss to the receiver.
-        int diff = RTPUtils.sequenceNumberDiff(seq, highestSeq);
+        int diff = RTPUtils.getSequenceNumberDelta(seq, highestSeq);
         if (diff <= 0)
         {
             // An old packet, already counted as not send. Un-not-send it ;)

--- a/src/org/jitsi/impl/neomedia/transform/RetransmissionRequesterImpl.java
+++ b/src/org/jitsi/impl/neomedia/transform/RetransmissionRequesterImpl.java
@@ -397,7 +397,7 @@ public class RetransmissionRequesterImpl
                 return;
             }
 
-            int diff = RTPUtils.sequenceNumberDiff(seq, lastReceivedSeq);
+            int diff = RTPUtils.getSequenceNumberDelta(seq, lastReceivedSeq);
             if (diff <= 0)
             {
                 // An older packet, possibly already requested.

--- a/src/org/jitsi/util/RTPUtils.java
+++ b/src/org/jitsi/util/RTPUtils.java
@@ -25,12 +25,13 @@ public class RTPUtils
 {
     /**
      * Returns the delta between two RTP sequence numbers, taking into account
-     * rollover.  This will return the 'shortest' delta between the two sequence numbers, e.g.:
-     * sequenceNumberDiff(1, 10) -> -9
-     * sequenceNumberBiff(1, 65530) -> 7
+     * rollover.  This will return the 'shortest' delta between the two
+     * sequence numbers in the form of the number you'd add to b to get a. e.g.:
+     * getSequenceNumberDelta(1, 10) -> -9 (10 + -9 = 1)
+     * getSequenceNumberDelta(1, 65530) -> 7 (65530 + 7 = 1)
      * @return the delta between two RTP sequence numbers (modulo 2^16).
      */
-    public static int sequenceNumberDiff(int a, int b)
+    public static int getSequenceNumberDelta(int a, int b)
     {
         int diff = a - b;
 
@@ -43,6 +44,18 @@ public class RTPUtils
     }
 
     /**
+     * Returns whether or not seqNumOne is 'older' than seqNumTwo, taking
+     * rollover into account
+     * @param seqNumOne
+     * @param seqNumTwo
+     * @return true if seqNumOne is 'older' than seqNumTwo
+     */
+    public static boolean isOlderSequenceNumberThan(int seqNumOne, int seqNumTwo)
+    {
+        return getSequenceNumberDelta(seqNumOne, seqNumTwo) < 0;
+    }
+
+    /**
      * Returns result of the subtraction of one RTP sequence number from another
      * (modulo 2^16).
      * @return result of the subtraction of one RTP sequence number from another
@@ -51,6 +64,20 @@ public class RTPUtils
     public static int subtractNumber(int a, int b)
     {
         return as16Bits(a - b);
+    }
+
+
+    /**
+     * Apply a delta to a given sequence number and return the result (taking
+     * rollover into account)
+     * @param startingSequenceNumber the starting sequence number
+     * @param delta the delta to be applied
+     * @return the sequence number result from doing
+     * startingSequenceNumber + delta
+     */
+    public static int applySequenceNumberDelta(int startingSequenceNumber, int delta)
+    {
+        return (startingSequenceNumber + delta) & 0xFFFF;
     }
 
     /**


### PR DESCRIPTION
… methods to RTPUtils.  rename 'sequenceNumberDiff' -> 'getSequenceNumberDelta'

i think  'delta' is clearer/more accurate than 'difference', since difference is typically thought of being a positive number ("the difference between 1 and 10 is 9.  the delta between 1 and 10 is -9").

the other helpers are things i've come across being done manually in jvb (jvb PR to come) 