### PR TITLE
DO NOT MERGE.  port over subset of the rtp-stack changes from fmj

### DIFF
--- a/src/org/jitsi/impl/neomedia/MediaStreamStatsImpl.java
+++ b/src/org/jitsi/impl/neomedia/MediaStreamStatsImpl.java
@@ -26,10 +26,9 @@ import javax.media.format.*;
 import javax.media.protocol.*;
 import javax.media.rtp.*;
 
-import net.sf.fmj.media.rtp.*;
-
 import org.jitsi.impl.neomedia.device.*;
 import org.jitsi.impl.neomedia.rtcp.*;
+import org.jitsi.impl.neomedia.rtcp.fmj_port.*;
 import org.jitsi.impl.neomedia.rtp.*;
 import org.jitsi.impl.neomedia.stats.*;
 import org.jitsi.impl.neomedia.transform.rtcp.*;

--- a/src/org/jitsi/impl/neomedia/rtcp/NACKPacket.java
+++ b/src/org/jitsi/impl/neomedia/rtcp/NACKPacket.java
@@ -16,7 +16,7 @@
 package org.jitsi.impl.neomedia.rtcp;
 
 import java.util.*;
-import net.sf.fmj.media.rtp.*;
+import org.jitsi.impl.neomedia.rtcp.fmj_port.*;
 import org.jitsi.service.neomedia.*;
 
 /**

--- a/src/org/jitsi/impl/neomedia/rtcp/RTCPFBPacket.java
+++ b/src/org/jitsi/impl/neomedia/rtcp/RTCPFBPacket.java
@@ -17,8 +17,7 @@ package org.jitsi.impl.neomedia.rtcp;
 
 import java.io.*;
 
-import net.sf.fmj.media.rtp.*;
-
+import org.jitsi.impl.neomedia.rtcp.fmj_port.*;
 import org.jitsi.service.neomedia.*;
 import org.jitsi.util.*;
 

--- a/src/org/jitsi/impl/neomedia/rtcp/RTCPPacketParserEx.java
+++ b/src/org/jitsi/impl/neomedia/rtcp/RTCPPacketParserEx.java
@@ -16,8 +16,8 @@
 package org.jitsi.impl.neomedia.rtcp;
 
 import java.io.*;
-import net.sf.fmj.media.rtp.*;
-import net.sf.fmj.media.rtp.util.*;
+
+import org.jitsi.impl.neomedia.rtcp.fmj_port.*;
 import org.jitsi.service.neomedia.*;
 import org.jitsi.service.neomedia.event.*;
 import org.jitsi.service.neomedia.rtp.*;
@@ -32,7 +32,7 @@ import org.jitsi.util.*;
  * @author Lyubomir Marinov
  */
 public class RTCPPacketParserEx
-    extends net.sf.fmj.media.rtp.RTCPPacketParser
+    extends RTCPPacketParser
 {
     /**
      * The <tt>Logger</tt> used by the <tt>RTCPPacketParserEx</tt> class and its

--- a/src/org/jitsi/impl/neomedia/rtcp/RTCPREMBPacket.java
+++ b/src/org/jitsi/impl/neomedia/rtcp/RTCPREMBPacket.java
@@ -18,9 +18,8 @@ package org.jitsi.impl.neomedia.rtcp;
 import java.io.*;
 import java.util.*;
 
-import net.sf.fmj.media.rtp.*;
-
 import org.jitsi.impl.neomedia.*;
+import org.jitsi.impl.neomedia.rtcp.fmj_port.*;
 import org.jitsi.service.neomedia.*;
 
 /**

--- a/src/org/jitsi/impl/neomedia/rtcp/RTCPReceiverFeedbackTermination.java
+++ b/src/org/jitsi/impl/neomedia/rtcp/RTCPReceiverFeedbackTermination.java
@@ -15,8 +15,10 @@
  */
 package org.jitsi.impl.neomedia.rtcp;
 
-import net.sf.fmj.media.rtp.*;
+import net.sf.fmj.media.rtp.SSRCCache;
+import net.sf.fmj.media.rtp.SSRCInfo;
 import org.jitsi.impl.neomedia.*;
+import org.jitsi.impl.neomedia.rtcp.fmj_port.*;
 import org.jitsi.impl.neomedia.rtp.*;
 import org.jitsi.impl.neomedia.rtp.remotebitrateestimator.*;
 import org.jitsi.impl.neomedia.rtp.translator.*;
@@ -283,8 +285,11 @@ public class RTCPReceiverFeedbackTermination
             }
             if (!info.ours && info.sender)
             {
+                // Create a libjits RTCPReportBlock type from the
+                // fmj RTCPReportBlock type we get from SSRCInfo
                 RTCPReportBlock reportBlock
-                    = info.makeReceiverReport(getLastProcessTime());
+                    = RTCPReportBlock.fromFmjRTCPReportBlock(
+                        info.makeReceiverReport(getLastProcessTime()));
                 reportBlocks.add(reportBlock);
             }
         }

--- a/src/org/jitsi/impl/neomedia/rtcp/RTCPTCCPacket.java
+++ b/src/org/jitsi/impl/neomedia/rtcp/RTCPTCCPacket.java
@@ -15,7 +15,7 @@
  */
 package org.jitsi.impl.neomedia.rtcp;
 
-import net.sf.fmj.media.rtp.*;
+import org.jitsi.impl.neomedia.rtcp.fmj_port.*;
 import org.jitsi.service.neomedia.*;
 import org.jitsi.util.*;
 

--- a/src/org/jitsi/impl/neomedia/rtcp/fmj_port/BadFormatException.java
+++ b/src/org/jitsi/impl/neomedia/rtcp/fmj_port/BadFormatException.java
@@ -1,0 +1,16 @@
+package org.jitsi.impl.neomedia.rtcp.fmj_port;
+
+/**
+ * NOTE(brian): was net.sf.fmj.media.rtp.util.BadFormatException
+ */
+public class BadFormatException extends Exception
+{
+    public BadFormatException()
+    {
+    }
+
+    public BadFormatException(String m)
+    {
+        super(m);
+    }
+}

--- a/src/org/jitsi/impl/neomedia/rtcp/fmj_port/BadVersionException.java
+++ b/src/org/jitsi/impl/neomedia/rtcp/fmj_port/BadVersionException.java
@@ -1,0 +1,12 @@
+package org.jitsi.impl.neomedia.rtcp.fmj_port;
+
+/**
+ * NOTE(brian): was net.sf.fmj.media.rtp.util.BadVersionException
+ */
+public class BadVersionException extends BadFormatException
+{
+    public BadVersionException(String s)
+    {
+        super(s);
+    }
+}

--- a/src/org/jitsi/impl/neomedia/rtcp/fmj_port/BurstMetrics.java
+++ b/src/org/jitsi/impl/neomedia/rtcp/fmj_port/BurstMetrics.java
@@ -1,0 +1,232 @@
+package org.jitsi.impl.neomedia.rtcp.fmj_port;
+
+/**
+ * NOTE(brian): was net.sf.fmj.media.rtp.BurstMetrics
+ */
+
+/**
+ * Represents the burst metrics (and packet loss and discard metrics) defined by
+ * RFC 3611 for VoIP Metrics Report Block and the algorithm for measuring them
+ * implemented in Appendix A.2.
+ *
+ * @author Lyubomir Marinov
+ */
+public class BurstMetrics
+{
+    /**
+     * The gap threshold.
+     */
+    private static final short GMIN = 16;
+
+    /**
+     * The burst metrics (and packet loss and discard metrics) measured by this
+     * algorithm.
+     */
+    private long burstMetrics;
+
+    /**
+     * The state transition counts defined by Appendix A.2 of RFC 3611.
+     */
+    private long c11, c13, c14, c22, c23, c33;
+
+    /**
+     * The indicator which determines whether the method {@link #calculate()} is
+     * to be invoked before reading {@link #burstMetrics} i.e. <tt>false</tt> if
+     * <tt>burstMetrics</tt> is calculated; otherwise, <tt>true</tt>.
+     */
+    private boolean calculate;
+
+    /**
+     * The number of packets discarded since the start of the reception.
+     */
+    private long discardCount;
+
+    /**
+     * The number of packets lost since the start of the reception.
+     */
+    private long lossCount;
+
+    /**
+     * The number of packets lost within the current burst.
+     */
+    private long lost;
+
+    /**
+     * The number of packets received since the last packet was declared lost or
+     * discarded.
+     */
+    private long pkt;
+
+    /**
+     * Calculates {@link #burstMetrics}.
+     */
+    private synchronized void calculate()
+    {
+        // Calculate additional transition counts.
+        long s1x = c11 + c13 + c14;
+        long s2x = c22 + c23;
+        long s3x = c13 + c23 + c33;
+        long s = s1x + s2x + s3x;
+
+        // Calculate burst and gap densities.
+        double p23 = (c22 <= 0) ? 1 : (1 - c22 / (double) s2x);
+        double p32 = (c23 <= 0) ? 0 : (c23 / (double) s3x);
+        long burstDensity;
+        long gapDensity;
+
+        if (p23 <= 0)
+        {
+            burstDensity = 0;
+        }
+        else
+        {
+            burstDensity = (long) (256 * p23 / (p23 + p32));
+            if (burstDensity > 255)
+                burstDensity = 255;
+        }
+        if (c14 <= 0)
+        {
+            gapDensity = 0;
+        }
+        else
+        {
+            gapDensity = (long) (256 * c14 / (double) (c11 + c14));
+            if (gapDensity > 255)
+                gapDensity = 255;
+        }
+
+        // Calculate burst and gap durations in ms.
+        long gapDuration;
+        long burstDuration;
+        int msPerPkt = 20;
+
+        if (c13 <= 0)
+        {
+            gapDuration = 0;
+            burstDuration = 0;
+        }
+        else
+        {
+            gapDuration = s1x * msPerPkt / c13;
+            burstDuration = s * msPerPkt / c13 - gapDuration;
+        }
+
+        // Calculate loss and discard rates.
+        long lossRate;
+        long discardRate;
+
+        if (s <= 0)
+        {
+            lossRate = 0;
+            discardRate = 0;
+        }
+        else
+        {
+            lossRate = 256 * lossCount / s;
+            if (lossRate > 255)
+                lossRate = 255;
+            discardRate = 256 * discardCount / s;
+            if (discardRate > 255)
+                discardRate = 255;
+        }
+
+        burstMetrics = lossRate & 0xFFL;
+        burstMetrics <<= 8;
+        burstMetrics |= discardRate & 0xFFL;
+        burstMetrics <<= 8;
+        burstMetrics |= burstDensity & 0xFFL;
+        burstMetrics <<= 8;
+        burstMetrics |= gapDensity & 0xFFL;
+        burstMetrics <<= 8;
+        burstMetrics |= burstDuration & 0xFFFFL;
+        burstMetrics <<= 16;
+        burstMetrics |= gapDuration & 0xFFFFL;
+        calculate = false;
+    }
+
+    /**
+     * Gets the burst metrics (and packet loss and discard metrics) measured by
+     * this algorithm.
+     *
+     * @return the burst metrics (and packet loss and discard metrics) measured
+     * by this algorithm as they appear in the VoIP Metrics Report Block i.e.
+     * 8-bit loss rate, 8-bit discard rate, 8-bit burst density, 8-bit gap
+     * density, 16-bit burst duration, and 16-bit gap duration.
+     */
+    public synchronized long getBurstMetrics()
+    {
+        if (calculate)
+            calculate();
+        return burstMetrics;
+    }
+
+    /**
+     * Gets the gap threshold.
+     *
+     * @return the gap threshold
+     */
+    public short getGMin()
+    {
+        return GMIN;
+    }
+
+    /**
+     * Notifies this algorithm that a packet has been received, lost, or
+     * discarded.
+     *
+     * @param which {@link RTPStats#PDUPROCSD}, {@link RTPStats#PDULOST}, or
+     * {@link RTPStats#PDUDROP}
+     */
+    public synchronized void update(int which)
+    {
+        boolean calculate;
+
+        if (which == RTPStats.PDULOST)
+        {
+            lossCount++;
+            calculate = true;
+        }
+        else if (which == RTPStats.PDUDROP)
+        {
+            discardCount++;
+            calculate = true;
+        }
+        else
+        {
+            pkt++;
+            calculate = false;
+        }
+        if (calculate)
+        {
+            if (pkt >= GMIN)
+            {
+                if (lost == 1)
+                {
+                    c14++;
+                }
+                else
+                {
+                    c13++;
+                    lost = 1;
+                }
+                c11 += pkt;
+            }
+            else
+            {
+                lost++;
+                if (pkt == 0)
+                {
+                    c33++;
+                }
+                else
+                {
+                    c23++;
+                    c22 += (pkt - 1);
+                }
+            }
+            pkt = 0;
+
+            this.calculate = true;
+        }
+    }
+}

--- a/src/org/jitsi/impl/neomedia/rtcp/fmj_port/Feedback.java
+++ b/src/org/jitsi/impl/neomedia/rtcp/fmj_port/Feedback.java
@@ -1,0 +1,20 @@
+package org.jitsi.impl.neomedia.rtcp.fmj_port;
+
+/**
+ * NOTE(brian): was javax.media.rtp.rtcp.Feedback
+ */
+public interface Feedback {
+    long getDLSR();
+
+    int getFractionLost();
+
+    long getJitter();
+
+    long getLSR();
+
+    long getNumLost();
+
+    long getSSRC();
+
+    long getXtndSeqNum();
+}

--- a/src/org/jitsi/impl/neomedia/rtcp/fmj_port/Packet.java
+++ b/src/org/jitsi/impl/neomedia/rtcp/fmj_port/Packet.java
@@ -1,0 +1,60 @@
+package org.jitsi.impl.neomedia.rtcp.fmj_port;
+
+import java.util.Date;
+
+/**
+ * NOTE(brian): was net.sf.fmj.media.rtp.util.Packet
+ * TODO: will need to decide what the future of this class looks like (and those
+ * that descend from it).  Where should this class be put?
+ * how does this compare/contrast with RawPacket?
+ */
+public class Packet
+{
+    public byte data[];
+    public int offset;
+    public int length;
+    public boolean received;
+    public long receiptTime;
+
+    /**
+     * The bitmap/flag mask that specifies the set of boolean attributes enabled
+     * for this <tt>RawPacket</tt>. The value is the logical sum of all of the
+     * set flags. The possible flags are defined by the <tt>FLAG_XXX</tt>
+     * constants of FMJ's {@link Buffer} class.
+     */
+    public int flags;
+
+    public Packet()
+    {
+        received = true;
+    }
+
+    public Packet(Packet p)
+    {
+        received = true;
+        data = p.data;
+        offset = p.offset;
+        length = p.length;
+        received = p.received;
+        receiptTime = p.receiptTime;
+
+        flags = p.flags;
+    }
+
+    @Override
+    public Packet clone()
+    {
+        Packet p = new Packet(this);
+        p.data = data.clone();
+        return p;
+    }
+
+    @Override
+    public String toString()
+    {
+        String s = "Packet of size " + length;
+        if (received)
+            s = s + " received at " + new Date(receiptTime);
+        return s;
+    }
+}

--- a/src/org/jitsi/impl/neomedia/rtcp/fmj_port/Participant.java
+++ b/src/org/jitsi/impl/neomedia/rtcp/fmj_port/Participant.java
@@ -1,0 +1,17 @@
+package org.jitsi.impl.neomedia.rtcp.fmj_port;
+
+import java.util.Vector;
+
+/**
+ * NOTE(brian): was javax.media.rtp.Participant
+ */
+public interface Participant
+{
+    public String getCNAME();
+
+    public Vector getReports();
+
+    public Vector getSourceDescription();
+
+    public Vector getStreams();
+}

--- a/src/org/jitsi/impl/neomedia/rtcp/fmj_port/RTCPAPPPacket.java
+++ b/src/org/jitsi/impl/neomedia/rtcp/fmj_port/RTCPAPPPacket.java
@@ -1,0 +1,69 @@
+package org.jitsi.impl.neomedia.rtcp.fmj_port;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+/**
+ * NOTE(brian): was net.sf.fmj.media.rtp.RTCPAPPPacket
+ */
+public class RTCPAPPPacket
+    extends RTCPPacket
+{
+    public int ssrc;
+    public int name;
+    public int subtype;
+    public byte data[];
+
+    public RTCPAPPPacket(int ssrc, int name, int subtype, byte data[])
+    {
+        if ((data.length & 3) != 0)
+            throw new IllegalArgumentException("Bad data length");
+        if (subtype < 0 || subtype > 31)
+            throw new IllegalArgumentException("Bad subtype");
+
+        this.ssrc = ssrc;
+        this.name = name;
+        this.subtype = subtype;
+        this.data = data;
+        super.type = APP;
+        super.received = false;
+    }
+
+    public RTCPAPPPacket(RTCPPacket parent)
+    {
+        super(parent);
+        super.type = APP;
+    }
+
+    @Override
+    public void assemble(DataOutputStream out) throws IOException
+    {
+        out.writeByte(128 + subtype);
+        out.writeByte(APP);
+        out.writeShort(2 + (data.length >> 2));
+        out.writeInt(ssrc);
+        out.writeInt(name);
+        out.write(data);
+    }
+
+    @Override
+    public int calcLength()
+    {
+        return 12 + data.length;
+    }
+
+    public String nameString(int name)
+    {
+        return "" + (char) (name >>> 24) + (char) (name >>> 16 & 0xff)
+                + (char) (name >>> 8 & 0xff) + (char) (name & 0xff);
+    }
+
+    @Override
+    public String toString()
+    {
+        return "\tRTCP APP Packet from SSRC " + ssrc + " with name "
+                + nameString(name) + " and subtype " + subtype
+                + "\n\tData (length " + data.length + "): " + new String(data)
+                + "\n";
+    }
+}

--- a/src/org/jitsi/impl/neomedia/rtcp/fmj_port/RTCPBYEPacket.java
+++ b/src/org/jitsi/impl/neomedia/rtcp/fmj_port/RTCPBYEPacket.java
@@ -1,0 +1,76 @@
+package org.jitsi.impl.neomedia.rtcp.fmj_port;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+/**
+ * NOTE(brian): was net.sf.fmj.media.rtp.RTCPBYEPacket
+ */
+public class RTCPBYEPacket
+    extends RTCPPacket
+{
+    int ssrc[];
+    byte reason[];
+
+    public RTCPBYEPacket(int ssrc[], byte reason[])
+    {
+        if (ssrc.length > 31)
+            throw new IllegalArgumentException("Too many SSRCs");
+
+        this.ssrc = ssrc;
+        this.reason = (reason == null) ? new byte[0] : reason;
+    }
+
+    public RTCPBYEPacket(RTCPPacket parent)
+    {
+        super(parent);
+        super.type = BYE;
+    }
+
+    @Override
+    public void assemble(DataOutputStream out) throws IOException
+    {
+        out.writeByte(128 + ssrc.length);
+        out.writeByte(BYE);
+        out.writeShort(ssrc.length
+                + (reason.length <= 0 ? 0 : reason.length + 4 >> 2));
+        for (int i = 0; i < ssrc.length; i++)
+            out.writeInt(ssrc[i]);
+
+        if (reason.length > 0)
+        {
+            out.writeByte(reason.length);
+            out.write(reason);
+            for (int i = (reason.length + 4 & -4) - reason.length - 1; i > 0; i--)
+                out.writeByte(0);
+        }
+    }
+
+    @Override
+    public int calcLength()
+    {
+        return 4 + (ssrc.length << 2)
+                + (reason.length <= 0 ? 0 : reason.length + 4 & -4);
+    }
+
+    @Override
+    public String toString()
+    {
+        return "\tRTCP BYE packet for sync source(s) "
+                + toString(ssrc)
+                + " for "
+                + (reason.length <= 0 ? "no reason" : "reason "
+                + new String(reason)) + "\n";
+    }
+
+    public String toString(int ints[])
+    {
+        if (ints.length == 0)
+            return "(none)";
+        String s = "" + ints[0];
+        for (int i = 1; i < ints.length; i++)
+            s = s + ", " + ints[i];
+
+        return s;
+    }
+}

--- a/src/org/jitsi/impl/neomedia/rtcp/fmj_port/RTCPCompoundPacket.java
+++ b/src/org/jitsi/impl/neomedia/rtcp/fmj_port/RTCPCompoundPacket.java
@@ -1,0 +1,108 @@
+package org.jitsi.impl.neomedia.rtcp.fmj_port;
+
+import org.jitsi.util.ByteBufferOutputStream;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+/**
+ * NOTE(brian): was net.sf.fmj.media.rtp.RTCPCompoundPacket
+ */
+public class RTCPCompoundPacket
+    extends RTCPPacket
+{
+    public RTCPPacket packets[];
+
+    public RTCPCompoundPacket(Packet base)
+    {
+        super(base);
+        super.type = COMPOUND;
+    }
+
+    public RTCPCompoundPacket(RTCPPacket packets[])
+    {
+        this.packets = packets;
+        super.type = COMPOUND;
+        super.received = false;
+    }
+
+    @Override
+    public void assemble(DataOutputStream out) throws IOException
+    {
+        throw new IllegalArgumentException("Recursive Compound Packet");
+    }
+
+    public void assemble(int len, boolean encrypted)
+    {
+        length = len;
+        offset = 0;
+
+        /*
+         * XXX We cannot reuse the data of super/this because it may be the same
+         * as the data of base at this time.
+         */
+        byte[] d = new byte[len];
+        ByteBufferOutputStream bbos = new ByteBufferOutputStream(d, 0, len);
+        DataOutputStream dos = new DataOutputStream(bbos);
+        int laststart;
+        try
+        {
+            if (encrypted)
+                offset += 4;
+            laststart = offset;
+            for (int i = 0; i < packets.length; i++)
+            {
+                laststart = bbos.size();
+                packets[i].assemble(dos);
+            }
+
+        } catch (IOException e)
+        {
+            throw new NullPointerException("Impossible IO Exception");
+        }
+        int prelen = bbos.size();
+        super.data = d;
+        if (prelen > len)
+            throw new NullPointerException("RTCP Packet overflow");
+        if (prelen < len)
+        {
+            if (data.length < len)
+                System.arraycopy(data, 0, data = new byte[len], 0, prelen);
+            data[laststart] |= 0x20;
+            data[len - 1] = (byte) (len - prelen);
+            int temp = (data[laststart + 3] & 0xff) + (len - prelen >> 2);
+            if (temp >= 256)
+                data[laststart + 2] += len - prelen >> 10;
+            data[laststart + 3] = (byte) temp;
+        }
+    }
+
+    @Override
+    public int calcLength()
+    {
+        if (packets == null || packets.length < 1)
+            throw new IllegalArgumentException("Bad RTCP Compound Packet");
+
+        int len = 0;
+
+        for (int i = 0; i < packets.length; i++)
+            len += packets[i].calcLength();
+        return len;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "RTCP Packet with the following subpackets:\n"
+                + toString(packets);
+    }
+
+    public String toString(RTCPPacket packets[])
+    {
+        String s = "";
+        for (int i = 0; i < packets.length; i++)
+            s = s + packets[i];
+
+        return s;
+    }
+}

--- a/src/org/jitsi/impl/neomedia/rtcp/fmj_port/RTCPFeedback.java
+++ b/src/org/jitsi/impl/neomedia/rtcp/fmj_port/RTCPFeedback.java
@@ -1,0 +1,142 @@
+package org.jitsi.impl.neomedia.rtcp.fmj_port;
+
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.io.IOException;
+
+/**
+ * NOTE(brian): was net.sf.fmj.media.rtp.RTCPFeedback
+ */
+public class RTCPFeedback
+    implements Feedback
+{
+    /**
+     * The size of a feedback report in bytes
+     */
+    public static final int SIZE = 24;
+
+    // The SSRC that this is feedback for
+    private long ssrc = 0;
+
+    // The fraction of packets lost
+    private int fractionLost = 0;
+
+    // The number of packets lost
+    private long numLost = 0;
+
+    // The extended highest sequence number
+    private long xtndSeqNum = 0;
+
+    // The jitter
+    private long jitter = 0;
+
+    // The LSR
+    private long lsr = 0;
+
+    // The DLSR
+    private long dlsr = 0;
+
+    /**
+     * Creates a new RTCP Feedback report
+     *
+     * @param data
+     *            The data to read from
+     * @param offset
+     *            The offset into the data where the report starts
+     * @param length
+     *            The length of the report
+     * @throws IOException
+     *             I/O Exception
+     */
+    public RTCPFeedback(byte[] data, int offset, int length) throws IOException
+    {
+        DataInputStream stream = new DataInputStream(new ByteArrayInputStream(
+                data, offset, length));
+        ssrc = stream.readInt() & RTPHeader.UINT_TO_LONG_CONVERT;
+        fractionLost = stream.readUnsignedByte();
+        numLost = (stream.readUnsignedShort() << 8) | stream.readUnsignedByte();
+        xtndSeqNum = stream.readInt() & RTPHeader.UINT_TO_LONG_CONVERT;
+        jitter = stream.readInt() & RTPHeader.UINT_TO_LONG_CONVERT;
+        lsr = stream.readInt() & RTPHeader.UINT_TO_LONG_CONVERT;
+        dlsr = stream.readInt() & RTPHeader.UINT_TO_LONG_CONVERT;
+    }
+
+    /**
+     * Returns the delay since last SR (DLSR).
+     *
+     * @return the delay since last SR (DLSR)
+     */
+    public long getDLSR()
+    {
+        return dlsr;
+    }
+
+    /**
+     * Returns the fraction of RTP data packets from source SSRC_n lost since
+     * the previous SR or RR packet was sent
+     *
+     * @return Returns the fraction of packets lost
+     */
+    public int getFractionLost()
+    {
+        return fractionLost;
+    }
+
+    /**
+     * Returns the interarrival jitter An estimate of the statistical variance
+     * of the RTP data packet interarrival time, measured in timestamp units and
+     * expressed as an unsigned integer.
+     *
+     * @return the interarrival jitter
+     */
+    public long getJitter()
+    {
+        return jitter;
+    }
+
+    /**
+     * Returns last SR timestamp (LSR).
+     *
+     * @return the last SR timestamp (LSR)
+     */
+    public long getLSR()
+    {
+        return lsr;
+    }
+
+    /**
+     * Returns the number of RTP data packets from source SSRC_n lost since the
+     * previous SR or RR packet was sent. This number is a cumulatative count
+     * (like most of the values used in the RFC).
+     *
+     * @return Returns the number of packets lost
+     */
+    public long getNumLost()
+    {
+        return numLost;
+    }
+
+    /**
+     * Returns the SSRC corresponding to the feedback.
+     *
+     * @return The SSRC
+     */
+    public long getSSRC()
+    {
+        return ssrc;
+    }
+
+    /**
+     * Returns the extended highest sequence number received. The low 16 bits
+     * contain the highest sequence number received in an RTP data packet from
+     * source SSRC_n, and the most significant 16 bits extend that sequence
+     * number with the corresponding count of sequence number cycles
+     *
+     * @return the extended highest sequence number received.
+     */
+    public long getXtndSeqNum()
+    {
+        return xtndSeqNum;
+    }
+
+}

--- a/src/org/jitsi/impl/neomedia/rtcp/fmj_port/RTCPHeader.java
+++ b/src/org/jitsi/impl/neomedia/rtcp/fmj_port/RTCPHeader.java
@@ -1,0 +1,220 @@
+package org.jitsi.impl.neomedia.rtcp.fmj_port;
+
+import net.sf.fmj.media.rtp.RTPHeader;
+
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.net.DatagramPacket;
+
+/**
+ * NOTE(brian): was net.sf.fmj.media.rtp.RTCPHeader
+ */
+public class RTCPHeader
+{
+    /**
+     * The current RTP version
+     */
+    public static final int VERSION = 2;
+
+    /**
+     * The number of bytes to skip for a SDES header
+     */
+    public static final int SDES_SKIP = 8;
+
+    /**
+     * An SDES CNAME header
+     */
+    public static final int SDES_CNAME = 1;
+
+    /**
+     * An SDES NAME header
+     */
+    public static final int SDES_NAME = 2;
+
+    /**
+     * An SDES EMAIL header
+     */
+    public static final int SDES_EMAIL = 3;
+
+    /**
+     * An SDES PHONE header
+     */
+    public static final int SDES_PHONE = 4;
+
+    /**
+     * An SDES LOC header
+     */
+    public static final int SDES_LOC = 5;
+
+    /**
+     * An SDES TOOL header
+     */
+    public static final int SDES_TOOL = 6;
+
+    /**
+     * An SDES NOTE header
+     */
+    public static final int SDES_NOTE = 7;
+
+    /**
+     * The size of the header in bytes
+     */
+    public static final int SIZE = 8;
+
+    // The masks and shifts of header items
+    private static final int VERSION_MASK = 0xc000;
+
+    private static final int VERSION_SHIFT = 14;
+
+    private static final int PADDING_MASK = 0x2000;
+
+    private static final int PADDING_SHIFT = 13;
+
+    private static final int RCOUNT_MASK = 0x1f00;
+
+    private static final int RCOUNT_SHIFT = 8;
+
+    private static final int TYPE_MASK = 0x00ff;
+
+    private static final int TYPE_SHIFT = 0;
+
+    // The first 16 bits
+    private int flags;
+
+    // The second 16 bits
+    private int length;
+
+    // The third and fourth 16 bits
+    private long ssrc;
+
+    /**
+     * Creates a new RTCPHeader
+     *
+     * @param data
+     *            The data to read the header from
+     * @param offset
+     *            The offset in the data to start
+     * @param length
+     *            The length of the data to read
+     * @throws IOException
+     *             I/O Exception
+     */
+    public RTCPHeader(byte data[], int offset, int length) throws IOException
+    {
+        DataInputStream stream = new DataInputStream(new ByteArrayInputStream(
+                data, offset, length));
+        // Read the header values
+        this.flags = stream.readUnsignedShort();
+        this.length = stream.readUnsignedShort();
+        this.ssrc = stream.readInt() & RTPHeader.UINT_TO_LONG_CONVERT;
+
+        if (getVersion() != VERSION)
+        {
+            throw new IOException("Invalid RTCP Version");
+        } else if (getLength() > length)
+        {
+            throw new IOException("Invalid Length");
+        }
+    }
+
+    /**
+     * Creates a new RTCPHeader
+     *
+     * @param packet
+     *            The packet from which to parse the header
+     * @throws IOException
+     *             I/O Exception
+     */
+    public RTCPHeader(DatagramPacket packet) throws IOException
+    {
+        this(packet.getData(), packet.getOffset(), packet.getLength());
+    }
+
+    /**
+     * Returns the RTCP header flags. This is a 16 bits short integer composed
+     * by: . the version number: 2 bits . the padding bit . the reception report
+     * count (RC): 5 bits . the packet type (PT): 8 bits
+     *
+     * @return the header flags (version|P|RC|PT)
+     */
+    public int getFlags()
+    {
+        return flags;
+    }
+
+    /**
+     * Returns the length of the RTCP packet
+     *
+     * @return The length of the RTCP packet
+     */
+    public int getLength()
+    {
+        return length;
+    }
+
+    /**
+     * Returns the type of RTCP packet (SR || RR)
+     *
+     * @return The type of the RTCP packet (SR or RR)
+     */
+    public short getPacketType()
+    {
+        return (short) ((getFlags() & TYPE_MASK) >> TYPE_SHIFT);
+    }
+
+    /**
+     * Returns the value of the padding bit, indicating if this individual RTCP
+     * packet contains some additional padding octets at the end which are not
+     * part of the control information but are included in the length field
+     *
+     * @return the padding value
+     */
+    public short getPadding()
+    {
+        return (short) ((getFlags() & PADDING_MASK) >> PADDING_SHIFT);
+    }
+
+    /**
+     * Returns the reception report count (RC). This represents the number of
+     * reception report blocks contained in this packet. A value of zero is
+     * valid.
+     *
+     * @return The number of reception blocks in the packet (0 is valid)
+     */
+    public short getReceptionCount()
+    {
+        return (short) ((getFlags() & RCOUNT_MASK) >> RCOUNT_SHIFT);
+    }
+
+    /**
+     * Returns the SSRC being described by this packet.
+     *
+     * @return The ssrc being described
+     */
+    public long getSsrc()
+    {
+        return ssrc;
+    }
+
+    /**
+     * Returns the version of the RTCP packet
+     *
+     * @return The RTP version implemented
+     */
+    public short getVersion()
+    {
+        return (short) ((getFlags() & VERSION_MASK) >> VERSION_SHIFT);
+    }
+
+    /**
+     * Displays the header
+     *
+     */
+    public void print()
+    {
+        System.err.println(getVersion() + "|" + getPadding() + "|"
+                + getReceptionCount() + "|" + getPacketType() + "|"
+                + getLength() + "|" + getSsrc());
+    }
+}

--- a/src/org/jitsi/impl/neomedia/rtcp/fmj_port/RTCPPacket.java
+++ b/src/org/jitsi/impl/neomedia/rtcp/fmj_port/RTCPPacket.java
@@ -1,0 +1,61 @@
+package org.jitsi.impl.neomedia.rtcp.fmj_port;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+/**
+ * NOTE(brian): was net.sf.fmj.media.rtp.RTCPPacket
+ */
+public abstract class RTCPPacket
+    extends Packet
+{
+    public Packet base;
+    public int type;
+    public static final int SR = 200;
+    public static final int RR = 201;
+    public static final int SDES = 202;
+    public static final int BYE = 203;
+    public static final int APP = 204;
+    public static final int COMPOUND = -1;
+
+    public RTCPPacket()
+    {
+    }
+
+    public RTCPPacket(Packet p)
+    {
+        super(p);
+        base = p;
+    }
+
+    public RTCPPacket(RTCPPacket parent)
+    {
+        super(parent);
+        base = parent.base;
+    }
+
+    /**
+     * Serializes/writes the binary representation of this <tt>RTCPPacket</tt>
+     * into a specific <tt>DataOutputStream</tt>.
+     *
+     * @param dataoutputstream the <tt>DataOutputStream</tt> into which the
+     * binary representation of this <tt>RTCPPacket</tt> is to be
+     * serialized/written.
+     * @throws IOException if an input/output error occurs during the
+     * serialization/writing of the binary representation of this
+     * <tt>RTCPPacket</tt>
+     */
+    public abstract void assemble(DataOutputStream dataoutputstream)
+            throws IOException;
+
+    /**
+     * Computes the length in <tt>byte</tt>s of this <tt>RTCPPacket</tt>,
+     * including the header and any padding. The value will be used to calculate
+     * the 16-bit <tt>length</tt> of this RTCP packet in 32-bit words minus one,
+     * including the header and any padding.
+     *
+     * @return the length in <tt>byte</tt>s of this <tt>RTCPPacket</tt>,
+     * including the header and any padding
+     */
+    public abstract int calcLength();
+}

--- a/src/org/jitsi/impl/neomedia/rtcp/fmj_port/RTCPPacketParser.java
+++ b/src/org/jitsi/impl/neomedia/rtcp/fmj_port/RTCPPacketParser.java
@@ -1,0 +1,499 @@
+package org.jitsi.impl.neomedia.rtcp.fmj_port;
+
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Vector;
+
+/**
+ * Created by gp on 6/23/14.
+ */
+public class RTCPPacketParser
+{
+    private final List<RTCPPacketParserListener> listeners
+            = new ArrayList<>();
+
+    public void addRtcpPacketParserListener(RTCPPacketParserListener listener)
+    {
+        if (listener == null)
+            throw new NullPointerException("listener");
+
+        synchronized (listeners)
+        {
+            if (!listeners.contains(listener))
+                listeners.add(listener);
+        }
+    }
+
+    private void onEnterSenderReport()
+    {
+        synchronized (listeners)
+        {
+            for (RTCPPacketParserListener l : listeners)
+            {
+                l.enterSenderReport();
+            }
+        }
+    }
+
+    private void onMalformedEndOfParticipation()
+    {
+        synchronized (listeners)
+        {
+            for (RTCPPacketParserListener l : listeners)
+            {
+                l.malformedEndOfParticipation();
+            }
+        }
+    }
+
+    private void onMalformedReceiverReport()
+    {
+        synchronized (listeners)
+        {
+            for (RTCPPacketParserListener l : listeners)
+            {
+                l.malformedReceiverReport();
+            }
+        }
+    }
+
+
+    private void onMalformedSenderReport()
+    {
+        synchronized (listeners)
+        {
+            for (RTCPPacketParserListener l : listeners)
+            {
+                l.malformedSenderReport();
+            }
+        }
+    }
+
+    private void onMalformedSourceDescription()
+    {
+        synchronized (listeners)
+        {
+            for (RTCPPacketParserListener l : listeners)
+            {
+                l.malformedSourceDescription();
+            }
+        }
+    }
+
+    private void onPayloadUknownType()
+    {
+        synchronized (listeners)
+        {
+            for (RTCPPacketParserListener l : listeners)
+            {
+                l.uknownPayloadType();
+            }
+        }
+    }
+
+    private void onVisitSenderReport(RTCPSRPacket rtcpSrPacket)
+    {
+        synchronized (listeners)
+        {
+            for (RTCPPacketParserListener l : listeners)
+            {
+                l.visitSendeReport(rtcpSrPacket);
+            }
+        }
+    }
+
+    public RTCPPacket parse(Packet packet) throws BadFormatException
+    {
+        RTCPCompoundPacket base = new RTCPCompoundPacket(packet);
+        Vector<RTCPPacket> subpackets = new Vector<RTCPPacket>(2);
+        DataInputStream in
+                = new DataInputStream(
+                new ByteArrayInputStream(
+                        base.data,
+                        base.offset,
+                        base.length));
+        try
+        {
+            int length;
+            for (int offset = 0; offset < base.length; offset += length)
+            {
+/*
+        0                   1                   2                   3
+        0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+header |V=2|P|    NA   |      PT       |             length            |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ */
+
+                // version (2 bits), padding (1 bit), 5 bits of data
+                int firstbyte = in.readUnsignedByte();
+
+                // version must be 2.
+                if ((firstbyte & 0xc0) != 128)
+                {
+                    throw new BadVersionException(
+                            "version must be 2. (base.length " + base.length
+                                    + ", base.offset " + base.offset
+                                    + ", firstbyte 0x"
+                                    + Integer.toHexString(firstbyte) + ", offset "
+                                    + offset + ")");
+                }
+
+                int type = in.readUnsignedByte(); // 8 bits
+
+                // length: 16 bits The length of this RTCP packet in 32-bit
+                // words minus one, including the header and any padding.
+                length = in.readUnsignedShort();
+                // packet length in bytes
+                length = length + 1 << 2;
+
+                if (offset + length > base.length)
+                {
+                    throw new BadFormatException(
+                            "Packet length less than actual packet length");
+                }
+
+                // find padding length, if any.
+                int padlen = 0;
+                if (offset + length == base.length)
+                {
+                    if ((firstbyte & 0x20) != 0)
+                    {
+                        // packet has padding.
+                        padlen
+                                = base.data[base.offset + base.length - 1] & 0xff;
+                        if (padlen == 0)
+                            throw new BadFormatException();
+                    }
+                } else if ((firstbyte & 0x20) != 0)
+                    throw new BadFormatException("No padding found.");
+
+                int inlength = length - padlen;
+
+                // discard version and padding from firstbyte.
+                int rc = firstbyte & 0x1f;
+                RTCPPacket p;
+                switch (type)
+                {
+                    case RTCPPacket.SR:
+/*
+        0                   1                   2                   3
+        0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+header |V=2|P|    RC   |   PT=SR=200   |             length            |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |                         SSRC of sender                        |
+       +=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+
+sender |              NTP timestamp, most significant word             |
+info   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |             NTP timestamp, least significant word             |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |                         RTP timestamp                         |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |                     sender's packet count                     |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |                      sender's octet count                     |
+       +=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+
+report |                 SSRC_1 (SSRC of first source)                 |
+block  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+  1    | fraction lost |       cumulative number of packets lost       |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |           extended highest sequence number received           |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |                      interarrival jitter                      |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |                         last SR (LSR)                         |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |                   delay since last SR (DLSR)                  |
+       +=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+
+report |                 SSRC_2 (SSRC of second source)                |
+block  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+  2    :                               ...                             :
+       +=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+
+       |                  profile-specific extensions                  |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ */
+                        onEnterSenderReport();
+                        if (inlength != 28 + 24 * rc)
+                        {
+                            onMalformedSenderReport();
+                            System.out.println("bad format.");
+                            throw new BadFormatException(
+                                    "inlength != 28 + 24 * firstbyte");
+                        }
+                        RTCPSRPacket srp = new RTCPSRPacket(base);
+                        p = srp;
+                        srp.ssrc = in.readInt();
+                        srp.ntptimestampmsw = in.readInt() & 0xffffffffL;
+                        srp.ntptimestamplsw = in.readInt() & 0xffffffffL;
+                        srp.rtptimestamp = in.readInt() & 0xffffffffL;
+                        srp.packetcount = in.readInt() & 0xffffffffL;
+                        srp.octetcount = in.readInt() & 0xffffffffL;
+                        srp.reports = new RTCPReportBlock[rc];
+                        onVisitSenderReport(srp);
+                        readRTCPReportBlock(in, srp.reports);
+                        break;
+
+                    case RTCPPacket.RR:
+/*
+        0                   1                   2                   3
+        0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+header |V=2|P|    RC   |   PT=RR=201   |             length            |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |                     SSRC of packet sender                     |
+       +=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+
+report |                 SSRC_1 (SSRC of first source)                 |
+block  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+  1    | fraction lost |       cumulative number of packets lost       |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |           extended highest sequence number received           |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |                      interarrival jitter                      |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |                         last SR (LSR)                         |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |                   delay since last SR (DLSR)                  |
+       +=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+
+report |                 SSRC_2 (SSRC of second source)                |
+block  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+  2    :                               ...                             :
+       +=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+
+       |                  profile-specific extensions                  |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ */
+                        if (inlength != 8 + 24 * rc)
+                        {
+                            onMalformedReceiverReport();
+                            throw new BadFormatException(
+                                    "inlength != 8 + 24 * firstbyte");
+                        }
+                        RTCPRRPacket rrp = new RTCPRRPacket(base);
+                        p = rrp;
+                        rrp.ssrc = in.readInt();
+                        rrp.reports = new RTCPReportBlock[rc];
+                        readRTCPReportBlock(in, rrp.reports);
+                        break;
+
+                    case RTCPPacket.SDES:
+/*
+        0                   1                   2                   3
+        0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+header |V=2|P|    SC   |  PT=SDES=202  |             length            |
+       +=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+
+chunk  |                          SSRC/CSRC_1                          |
+  1    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |                           SDES items                          |
+       |                              ...                              |
+       +=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+
+chunk  |                          SSRC/CSRC_2                          |
+  2    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |                           SDES items                          |
+       |                              ...                              |
+       +=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+
+ */
+                        RTCPSDESPacket sdesp = new RTCPSDESPacket(base);
+                        p = sdesp;
+                        sdesp.sdes = new RTCPSDES[rc];
+                        int sdesoff = 4;
+                        for (int i = 0; i < sdesp.sdes.length; i++)
+                        {
+                            RTCPSDES chunk = new RTCPSDES();
+                            sdesp.sdes[i] = chunk;
+                            chunk.ssrc = in.readInt();
+                            sdesoff += 5;
+                            Vector<RTCPSDESItem> items
+                                    = new Vector<RTCPSDESItem>();
+                            boolean gotcname = false;
+                            int j;
+                            while ((j = in.readUnsignedByte()) != 0)
+                            {
+                                if (j < 1 || j > 8)
+                                {
+                                    onMalformedSourceDescription();
+                                    throw new BadFormatException(
+                                            "j < 1 || j > 8");
+                                }
+                                if (j == 1)
+                                    gotcname = true;
+                                RTCPSDESItem item = new RTCPSDESItem();
+                                items.addElement(item);
+                                item.type = j;
+                                int sdeslen = in.readUnsignedByte();
+                                item.data = new byte[sdeslen];
+                                in.readFully(item.data);
+                                sdesoff += 2 + sdeslen;
+                            }
+                            if (!gotcname)
+                            {
+                                onMalformedSourceDescription();
+                                throw new BadFormatException("!gotcname");
+                            }
+                            chunk.items = new RTCPSDESItem[items.size()];
+                            items.copyInto(chunk.items);
+                            if ((sdesoff & 3) != 0)
+                            {
+                                in.skip(4 - (sdesoff & 3));
+                                sdesoff = sdesoff + 3 & -4;
+                            }
+                        }
+
+                        if (inlength != sdesoff)
+                        {
+                            onMalformedSourceDescription();
+                            throw new BadFormatException("inlength != sdesoff");
+                        }
+                        break;
+
+                    case RTCPPacket.BYE:
+/*
+       0                   1                   2                   3
+       0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |V=2|P|    SC   |   PT=BYE=203  |             length            |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |                           SSRC/CSRC                           |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      :                              ...                              :
+      +=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+
+(opt) |     length    |               reason for leaving            ...
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ */
+                        RTCPBYEPacket byep = new RTCPBYEPacket(base);
+                        p = byep;
+                        byep.ssrc = new int[rc];
+                        for (int i = 0; i < byep.ssrc.length; i++)
+                            byep.ssrc[i] = in.readInt();
+
+                        int reasonlen;
+                        if (inlength > 4 + 4 * rc)
+                        {
+                            reasonlen = in.readUnsignedByte();
+                            byep.reason = new byte[reasonlen];
+                            reasonlen++;
+                        } else
+                        {
+                            reasonlen = 0;
+                            byep.reason = new byte[0];
+                        }
+                        reasonlen = reasonlen + 3 & -4;
+                        if (inlength != 4 + 4 * rc + reasonlen)
+                        {
+                            onMalformedEndOfParticipation();
+                            throw new BadFormatException(
+                                    "inlength != 4 + 4 * firstbyte + reasonlen");
+                        }
+                        in.readFully(byep.reason);
+                        in.skip(reasonlen - byep.reason.length);
+                        break;
+
+                    case RTCPPacket.APP:
+/*
+    0                   1                   2                   3
+    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |V=2|P| subtype |   PT=APP=204  |             length            |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |                           SSRC/CSRC                           |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |                          name (ASCII)                         |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |                   application-dependent data                ...
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ */
+                        if (inlength < 12)
+                            throw new BadFormatException("inlength < 12");
+                        RTCPAPPPacket appp = new RTCPAPPPacket(base);
+                        p = appp;
+                        appp.ssrc = in.readInt();
+                        appp.name = in.readInt();
+                        appp.subtype = rc;
+                        appp.data = new byte[inlength - 12];
+                        in.readFully(appp.data);
+                        in.skip(inlength - 12 - appp.data.length);
+                        break;
+                    default:
+
+                        // Give a chance to an extended parser to parse the packet.
+                        p = parse(base, firstbyte, type, inlength, in);
+
+                        if (p == null)
+                        {
+                            onPayloadUknownType();
+                            throw new BadFormatException("p == null");
+                        }
+                        break;
+                }
+
+                p.offset = offset;
+                p.length = length;
+                subpackets.addElement(p);
+                in.skipBytes(padlen);
+            }
+
+        } catch (EOFException e)
+        {
+            throw new BadFormatException(
+                    "Failed to parse an RTCP packet: " + e.getMessage());
+        }
+        catch (IOException e)
+        {
+            throw new IllegalArgumentException(
+                    "Failed to parse an RTCP packet: ", e);
+        }
+        base.packets = new RTCPPacket[subpackets.size()];
+        subpackets.copyInto(base.packets);
+        return base;
+    }
+
+    protected RTCPPacket parse(
+            RTCPCompoundPacket base,
+            int firstbyte,
+            int type,
+            int length,
+            DataInputStream in)
+            throws BadFormatException, IOException
+    {
+        onPayloadUknownType();
+        throw new BadFormatException("Unknown payload type");
+    }
+
+    private void readRTCPReportBlock(
+            DataInputStream in,
+            RTCPReportBlock[] reports)
+            throws IOException
+    {
+        for (int i = 0; i < reports.length; i++)
+        {
+            RTCPReportBlock report = new RTCPReportBlock();
+            reports[i] = report;
+            report.ssrc = in.readInt();
+            long val = in.readInt();
+            val &= 0xffffffffL;
+            report.fractionlost = (int) (val >> 24);
+            report.packetslost = (int) (val & 0xffffffL);
+            report.lastseq = in.readInt() & 0xffffffffL;
+            report.jitter = in.readInt();
+            report.lsr = in.readInt() & 0xffffffffL;
+            report.dlsr = in.readInt() & 0xffffffffL;
+        }
+    }
+
+    public void removeRtcpPacketParserListener(
+            RTCPPacketParserListener listener)
+    {
+        if (listener != null)
+        {
+            synchronized (listeners)
+            {
+                listeners.remove(listener);
+            }
+        }
+    }
+}
+

--- a/src/org/jitsi/impl/neomedia/rtcp/fmj_port/RTCPPacketParserListener.java
+++ b/src/org/jitsi/impl/neomedia/rtcp/fmj_port/RTCPPacketParserListener.java
@@ -1,0 +1,21 @@
+package org.jitsi.impl.neomedia.rtcp.fmj_port;
+
+/**
+ * NOTE(brian): was net.sf.fmj.media.rtp.RTCPPacketParserListener
+ */
+public interface RTCPPacketParserListener
+{
+    void enterSenderReport();
+
+    void malformedSenderReport();
+
+    void malformedReceiverReport();
+
+    void malformedSourceDescription();
+
+    void malformedEndOfParticipation();
+
+    void uknownPayloadType();
+
+    void visitSendeReport(RTCPSRPacket rtcpSrPacket);
+}

--- a/src/org/jitsi/impl/neomedia/rtcp/fmj_port/RTCPRRPacket.java
+++ b/src/org/jitsi/impl/neomedia/rtcp/fmj_port/RTCPRRPacket.java
@@ -1,0 +1,61 @@
+package org.jitsi.impl.neomedia.rtcp.fmj_port;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+/**
+ * NOTE(brian): was net.sf.fmj.media.rtp.RTCPRRPacket
+ */
+public class RTCPRRPacket
+    extends RTCPPacket
+{
+    public int ssrc;
+    public RTCPReportBlock reports[];
+
+    public RTCPRRPacket(int ssrc, RTCPReportBlock reports[])
+    {
+        if (reports.length > 31)
+            throw new IllegalArgumentException("Too many reports");
+
+        this.ssrc = ssrc;
+        this.reports = reports;
+    }
+
+    RTCPRRPacket(RTCPPacket parent)
+    {
+        super(parent);
+        super.type = RR;
+    }
+
+    @Override
+    public void assemble(DataOutputStream out) throws IOException
+    {
+        out.writeByte(128 + reports.length);
+        out.writeByte(RR);
+        out.writeShort(1 + reports.length * 6);
+        out.writeInt(ssrc);
+        for (int i = 0; i < reports.length; i++)
+        {
+            out.writeInt(reports[i].ssrc);
+            out.writeInt((reports[i].packetslost & 0xffffff)
+                    + (reports[i].fractionlost << 24));
+            out.writeInt((int) reports[i].lastseq);
+            out.writeInt(reports[i].jitter);
+            out.writeInt((int) reports[i].lsr);
+            out.writeInt((int) reports[i].dlsr);
+        }
+    }
+
+    @Override
+    public int calcLength()
+    {
+        return 8 + reports.length * 24;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "\tRTCP RR (receiver report) packet for sync source " + ssrc
+                + ":\n" + RTCPReportBlock.toString(reports);
+    }
+}

--- a/src/org/jitsi/impl/neomedia/rtcp/fmj_port/RTCPReceiverReport.java
+++ b/src/org/jitsi/impl/neomedia/rtcp/fmj_port/RTCPReceiverReport.java
@@ -1,0 +1,26 @@
+package org.jitsi.impl.neomedia.rtcp.fmj_port;
+
+import java.io.IOException;
+
+/**
+ * NOTE(brian): was net.sf.fmj.media.rtp.RTCPReceiverReport
+ */
+public class RTCPReceiverReport
+        extends RTCPReport
+        implements ReceiverReport
+{
+    /**
+     * Initializes a new <tt>RTCPReceiverReport</tt> instance.
+     *
+     * @param data the data of the report
+     * @param offset the offset of the report in the data
+     * @param length the length of the data
+     * @throws IOException if an I/O error occurs while initializing the new
+     * instance from the specified data
+     */
+    public RTCPReceiverReport(byte[] data, int offset, int length)
+            throws IOException
+    {
+        super(data, offset, length);
+    }
+}

--- a/src/org/jitsi/impl/neomedia/rtcp/fmj_port/RTCPReport.java
+++ b/src/org/jitsi/impl/neomedia/rtcp/fmj_port/RTCPReport.java
@@ -1,0 +1,321 @@
+package org.jitsi.impl.neomedia.rtcp.fmj_port;
+
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.util.Vector;
+
+/**
+ * NOTE(brian): was net.sf.fmj.media.rtp.RTCPReport
+ */
+public abstract class RTCPReport
+    implements Report
+{
+    // The reason for leaving if this is a bye packet
+    private String byeReason = "";
+
+    // The CNAME of the source
+    private String cName = null;
+
+    // The vector of feedback reports in this report
+    protected Vector<RTCPFeedback> feedbackReports = new Vector<RTCPFeedback>();
+
+    // The header of the report
+    protected RTCPHeader header;
+
+    // True if this is a bye event
+    private boolean isBye = false;
+
+    // The participant that sent the report
+    protected Participant participant;
+
+    // The number of bytes of SDES packets read
+    protected int sdesBytes = 0;
+
+    // The source descriptions in the report
+    protected Vector<SourceDescription> sourceDescriptions
+            = new Vector<SourceDescription>();
+
+    // The ssrc of the report
+    private long ssrc = 0;
+
+    /**
+     * The <tt>System</tt> time in milliseconds at which this
+     * <tt>RTCPReport</tt> has been received or sent by the local endpoint.
+     */
+    private long systemTimeStamp;
+
+    /**
+     * Creates a new <tt>RTCPReport</tt> instance.
+     *
+     * @param data the data of the report
+     * @param offset the offset in the data where the report starts
+     * @param length the length of the report in the data
+     * @throws IOException if an I/O-related error is encountered
+     */
+    public RTCPReport(byte data[], int offset, int length) throws IOException
+    {
+        header = new RTCPHeader(data, offset, length);
+
+        if (header.getPadding() == 1)
+            throw new IOException("First packet has padding");
+        else if (((header.getLength() + 1) * 4) > length)
+            throw new IOException("Invalid Length");
+
+        ssrc = header.getSsrc();
+
+        /*
+         * We know the forms of the RTCP sender report (SR) and receiver report
+         * (RR). Additionally, we know that they differ, besides the packet type
+         * (PT), by a 20-byte sender information section.
+         */
+        int rtcpReportBlockOffset = RTCPHeader.SIZE;
+
+        switch (header.getPacketType())
+        {
+            case RTCPPacket.SR:
+                rtcpReportBlockOffset += RTCPSenderInfo.SIZE;
+                //$FALL-THROUGH$
+            case RTCPPacket.RR:
+                readFeedbackReports(
+                        data,
+                        offset + rtcpReportBlockOffset,
+                        length - rtcpReportBlockOffset);
+                // Read any source descriptions
+                offset += (header.getLength() + 1) * 4;
+                length -= (header.getLength() + 1) * 4;
+                readSourceDescription(data, offset, length);
+                offset += sdesBytes;
+                length -= sdesBytes;
+                readBye(data, offset, length);
+                break;
+            default:
+                // We do not know about any other RTCP report.
+                break;
+        }
+    }
+
+    /**
+     * Returns the reason for the bye
+     *
+     * @return the reason announced for this BYE packet
+     */
+    public String getByeReason()
+    {
+        return byeReason;
+    }
+
+    /**
+     * Gets the cName of the source of the report
+     *
+     * @return the cName, or null if none sent
+     */
+    public String getCName()
+    {
+        return cName;
+    }
+
+    /**
+     * Returns the feedback reports for this RTCP report.
+     *
+     * @return the feedback reports for this RTCP report
+     */
+    public Vector<RTCPFeedback> getFeedbackReports()
+    {
+        return feedbackReports;
+    }
+
+    /**
+     * Returns the participant linked with this RTCP report
+     *
+     * @return the participant identified previously as being linked with this
+     *         RTCP report
+     */
+    public Participant getParticipant()
+    {
+        return participant;
+    }
+
+    /**
+     * Returns the sources descriptions (SDES) in this RTCP report.
+     *
+     * @return the sources descriptions (SDES) in this RTCP report
+     */
+    public Vector<SourceDescription> getSourceDescription()
+    {
+        return sourceDescriptions;
+    }
+
+    /**
+     * Returns the SSRC announced in this report.
+     *
+     * @return SSRC in this report
+     */
+    public long getSSRC()
+    {
+        return ssrc;
+    }
+
+    /**
+     * Gets the <tt>System</tt> time in milliseconds at which this
+     * <tt>RTCPReport</tt> has been received or sent by the local endpoint.
+     *
+     * @return the <tt>System</tt> time in milliseconds at which this
+     * <tt>RTCPReport</tt> has been received or sent by the local endpoint
+     */
+    public long getSystemTimeStamp()
+    {
+        return systemTimeStamp;
+    }
+
+    /**
+     * Returns true if a bye packet was added to the report
+     *
+     * @return true if a BYE packet was added to the report
+     */
+    public boolean isByePacket()
+    {
+        return isBye;
+    }
+
+    /**
+     * Reads and handles the BYE part of an RTCP report.
+     *
+     * @param data
+     *            the raw data in which the packet is contained
+     * @param offset
+     *            the offset where the BYE starts
+     * @param length
+     *            the length of the report
+     * @throws java.io.IOException
+     *             I/O Exception
+     */
+    protected void readBye(byte data[], int offset, int length)
+            throws IOException
+    {
+        if (length > 0)
+        {
+            RTCPHeader sdesHeader = new RTCPHeader(data, offset, length);
+            if (sdesHeader.getPacketType() == RTCPPacket.BYE)
+            {
+                isBye = true;
+                if (((sdesHeader.getLength() + 1) * 4) > RTCPHeader.SIZE)
+                {
+                    int reasonLen = data[offset + RTCPHeader.SIZE] & 0xFF;
+                    if ((reasonLen < (length - RTCPHeader.SIZE))
+                            && (reasonLen > 0))
+                    {
+                        byeReason = new String(data, offset + RTCPHeader.SIZE
+                                + 1, reasonLen);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Reads feedback reports from the data
+     *
+     * @param data
+     *            The data to read the feedback reports from
+     * @param offset
+     *            The offset into the data where the reports start
+     * @param length
+     *            The length of the data
+     * @throws IOException
+     *             I/O Exception
+     */
+    protected void readFeedbackReports(byte data[], int offset, int length)
+            throws IOException
+    {
+        for (int i = 0; i < header.getReceptionCount(); i++)
+        {
+            RTCPFeedback feedback = new RTCPFeedback(data, offset, length);
+            feedbackReports.add(feedback);
+            offset += RTCPFeedback.SIZE;
+        }
+    }
+
+    /**
+     * Reads the source description from the data
+     *
+     * @param data
+     *            The data to read the source description from
+     * @param offset
+     *            The offset into the data where the SDES packet starts
+     * @param length
+     *            The length of the data
+     * @throws IOException
+     *             I/O Exception
+     */
+    protected void readSourceDescription(byte data[], int offset, int length)
+            throws IOException
+    {
+        if (length > 0)
+        {
+            // Only do this if there is an SDES header
+            RTCPHeader sdesHeader = new RTCPHeader(data, offset, length);
+
+            if (sdesHeader.getPacketType() == RTCPPacket.SDES)
+            {
+                ssrc = sdesHeader.getSsrc();
+                sdesBytes = (sdesHeader.getLength() + 1) * 4;
+                DataInputStream stream = new DataInputStream(
+                        new ByteArrayInputStream(data,
+                                offset + RTCPHeader.SIZE, length));
+                int type = SourceDescription.SOURCE_DESC_CNAME;
+                while (type != 0)
+                {
+                    type = stream.readUnsignedByte();
+                    if (type != 0)
+                    {
+                        int len = stream.readUnsignedByte();
+                        byte[] desc = new byte[len];
+                        stream.readFully(desc);
+                        String descStr = new String(desc, "UTF-8");
+                        SourceDescription description = new SourceDescription(
+                                type, descStr, 0, false);
+                        sourceDescriptions.add(description);
+                        if (type == SourceDescription.SOURCE_DESC_CNAME)
+                        {
+                            cName = descStr;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Sets the participant linked with this RTCP report.
+     *
+     * @param participant
+     *            the participant identified as linked with this RTCP report
+     */
+    protected void setParticipant(RTPParticipant participant)
+    {
+        this.participant = participant;
+        Vector streams = participant.getStreams();
+        if (streams.size() == 0)
+        {
+            Vector sdes = participant.getSourceDescription();
+            for (int i = 0; i < sdes.size(); i++)
+            {
+                SourceDescription sdesItem = (SourceDescription) sdes.get(i);
+                participant.addSourceDescription(sdesItem);
+            }
+        }
+    }
+
+    /**
+     * Sets the <tt>System</tt> time in milliseconds at which this
+     * <tt>RTCPReport</tt> has been received or sent by the local endpoint.
+     *
+     * @param systemTimeStamp the <tt>System</tt> time in milliseconds at which
+     * this <tt>RTCPReport</tt> has been received or sent by the local endpoint
+     */
+    public void setSystemTimeStamp(long systemTimeStamp)
+    {
+        this.systemTimeStamp = systemTimeStamp;
+    }
+}

--- a/src/org/jitsi/impl/neomedia/rtcp/fmj_port/RTCPReportBlock.java
+++ b/src/org/jitsi/impl/neomedia/rtcp/fmj_port/RTCPReportBlock.java
@@ -1,0 +1,124 @@
+package org.jitsi.impl.neomedia.rtcp.fmj_port;
+
+import net.sf.fmj.media.rtp.*;
+
+/**
+ * NOTE(brian): was net.sf.fmj.media.rtp.RTCPReportBlock
+ */
+public class RTCPReportBlock
+    implements Feedback
+{
+    public static String toString(RTCPReportBlock reports[])
+    {
+        String s = "";
+        for (int i = 0; i < reports.length; i++)
+            s = s + reports[i];
+
+        return s;
+    }
+
+    /**
+     * NOTE(brian): RTCPReceiverFeedbackTermination calls
+     * {@link SSRCInfo#makeReceiverReport(long)} which returns an FMJ
+     * RTCPReportBlock.  Not going to port over SSRCInfo, so instead use
+     * this conversion function to get the ported-over RTCPReportBlock
+     * @param fmjRtcpReportBlock
+     * @return
+     */
+    public static RTCPReportBlock fromFmjRTCPReportBlock(
+        net.sf.fmj.media.rtp.RTCPReportBlock fmjRtcpReportBlock)
+    {
+        RTCPReportBlock rtcpReportBlock = new RTCPReportBlock(
+            (int)fmjRtcpReportBlock.getSSRC(),
+            fmjRtcpReportBlock.getFractionLost(),
+            (int)fmjRtcpReportBlock.getNumLost(),
+            fmjRtcpReportBlock.getXtndSeqNum(),
+            (int)fmjRtcpReportBlock.getJitter(),
+            fmjRtcpReportBlock.getLSR(),
+            fmjRtcpReportBlock.getDLSR()
+        );
+        rtcpReportBlock.receiptTime = fmjRtcpReportBlock.receiptTime;
+        return rtcpReportBlock;
+    }
+
+    int ssrc;
+    int fractionlost;
+    int packetslost;
+    long lastseq;
+    int jitter;
+    long lsr;
+    long dlsr;
+
+    public long receiptTime;
+
+    public RTCPReportBlock(int ssrc,
+                           int fractionlost,
+                           int packetslost,
+                           long lastseq,
+                           int jitter,
+                           long lsr,
+                           long dlsr)
+    {
+        this.ssrc = ssrc;
+        this.fractionlost = fractionlost;
+        this.packetslost = packetslost;
+        this.lastseq = lastseq;
+        this.jitter = jitter;
+        this.lsr = lsr;
+        this.dlsr = dlsr;
+    }
+
+    public RTCPReportBlock()
+    {
+    }
+
+    public long getDLSR()
+    {
+        return dlsr;
+    }
+
+    public int getFractionLost()
+    {
+        return fractionlost;
+    }
+
+    public long getJitter()
+    {
+        return jitter;
+    }
+
+    public long getLSR()
+    {
+        return lsr;
+    }
+
+    public long getNumLost()
+    {
+        return packetslost;
+    }
+
+    public long getSSRC()
+    {
+        return ssrc;
+    }
+
+    public long getXtndSeqNum()
+    {
+        return lastseq;
+    }
+
+    @Override
+    public String toString()
+    {
+        long printssrc = 0xFFFFFFFFL & ssrc;
+
+        return "\t\tFor source " + printssrc
+                + "\n\t\t\tFraction of packets lost: " + fractionlost + " ("
+                + fractionlost / 256D + ")" + "\n\t\t\tPackets lost: "
+                + packetslost + "\n\t\t\tLast sequence number: " + lastseq
+                + "\n\t\t\tJitter: " + jitter
+                + "\n\t\t\tLast SR packet received at time " + lsr
+                + "\n\t\t\tDelay since last SR packet received: " + dlsr + " ("
+                + dlsr / 65536D + " seconds)\n";
+    }
+}

--- a/src/org/jitsi/impl/neomedia/rtcp/fmj_port/RTCPSDES.java
+++ b/src/org/jitsi/impl/neomedia/rtcp/fmj_port/RTCPSDES.java
@@ -1,0 +1,31 @@
+package org.jitsi.impl.neomedia.rtcp.fmj_port;
+
+/**
+ * NOTE(brian): was net.sf.fmj.media.rtp.RTCPSDES
+ */
+public class RTCPSDES
+{
+    public static String toString(RTCPSDES chunks[])
+    {
+        String s = "";
+        for (int i = 0; i < chunks.length; i++)
+            s = s + chunks[i];
+
+        return s;
+    }
+
+    public int ssrc;
+
+    public RTCPSDESItem items[];
+
+    public RTCPSDES()
+    {
+    }
+
+    @Override
+    public String toString()
+    {
+        return "\t\tSource Description for sync source " + ssrc + ":\n"
+                + RTCPSDESItem.toString(items);
+    }
+}

--- a/src/org/jitsi/impl/neomedia/rtcp/fmj_port/RTCPSDESItem.java
+++ b/src/org/jitsi/impl/neomedia/rtcp/fmj_port/RTCPSDESItem.java
@@ -1,0 +1,54 @@
+package org.jitsi.impl.neomedia.rtcp.fmj_port;
+
+/**
+ * NOTE(brian): was net.sf.fmj.media.rtp.RTCPSDESItem
+ */
+public class RTCPSDESItem
+{
+    public int type;
+    public byte data[];
+    public static final int CNAME = 1;
+    public static final int NAME = 2;
+    public static final int EMAIL = 3;
+    public static final int PHONE = 4;
+    public static final int LOC = 5;
+    public static final int TOOL = 6;
+    public static final int NOTE = 7;
+    public static final int PRIV = 8;
+    public static final int HIGHEST = 8;
+    public static final String names[] = { "CNAME", "NAME", "EMAIL", "PHONE",
+            "LOC", "TOOL", "NOTE", "PRIV" };
+
+    public static String toString(RTCPSDESItem items[])
+    {
+        String s = "";
+        for (int i = 0; i < items.length; i++)
+            s = s + items[i];
+
+        return s;
+    }
+
+    public RTCPSDESItem()
+    {
+    }
+
+    public RTCPSDESItem(int type, byte[] data)
+    {
+        this.type = type;
+        this.data = data;
+    }
+
+    public RTCPSDESItem(int type, String s)
+    {
+        this.type = type;
+        data = new byte[s.length()];
+        data = s.getBytes();
+    }
+
+    @Override
+    public String toString()
+    {
+        return "\t\t\t" + names[type - 1] + ": " + new String(data) + "\n";
+    }
+
+}

--- a/src/org/jitsi/impl/neomedia/rtcp/fmj_port/RTCPSDESPacket.java
+++ b/src/org/jitsi/impl/neomedia/rtcp/fmj_port/RTCPSDESPacket.java
@@ -1,0 +1,73 @@
+package org.jitsi.impl.neomedia.rtcp.fmj_port;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+/**
+ * NOTE(brian): was net.sf.fmj.media.rtp.RTCPSDESPacket
+ */
+public class RTCPSDESPacket
+    extends RTCPPacket
+{
+    public RTCPSDES sdes[];
+
+    public RTCPSDESPacket(RTCPPacket parent)
+    {
+        super(parent);
+        super.type = SDES;
+    }
+
+    public RTCPSDESPacket(RTCPSDES sdes[])
+    {
+        if (sdes.length > 31)
+            throw new IllegalArgumentException("Too many SDESs");
+
+        this.sdes = sdes;
+    }
+
+    @Override
+    public void assemble(DataOutputStream out) throws IOException
+    {
+        out.writeByte(128 + sdes.length);
+        out.writeByte(SDES);
+        out.writeShort(calcLength() - 4 >> 2);
+        for (int i = 0; i < sdes.length; i++)
+        {
+            out.writeInt(sdes[i].ssrc);
+            int sublen = 0;
+            for (int j = 0; j < sdes[i].items.length; j++)
+            {
+                out.writeByte(sdes[i].items[j].type);
+                out.writeByte(sdes[i].items[j].data.length);
+                out.write(sdes[i].items[j].data);
+                sublen += 2 + sdes[i].items[j].data.length;
+            }
+
+            for (int j = (sublen + 4 & -4) - sublen; j > 0; j--)
+                out.writeByte(0);
+        }
+    }
+
+    @Override
+    public int calcLength()
+    {
+        int len = 4;
+        for (int i = 0; i < sdes.length; i++)
+        {
+            int sublen = 5;
+            for (int j = 0; j < sdes[i].items.length; j++)
+                sublen += 2 + sdes[i].items[j].data.length;
+
+            sublen = sublen + 3 & -4;
+            len += sublen;
+        }
+
+        return len;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "\tRTCP SDES Packet:\n" + RTCPSDES.toString(sdes);
+    }
+}

--- a/src/org/jitsi/impl/neomedia/rtcp/fmj_port/RTCPSRPacket.java
+++ b/src/org/jitsi/impl/neomedia/rtcp/fmj_port/RTCPSRPacket.java
@@ -1,0 +1,77 @@
+package org.jitsi.impl.neomedia.rtcp.fmj_port;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+/**
+ * NOTE(brian): was net.sf.fmj.media.rtp.RTCPSRPacket
+ */
+public class RTCPSRPacket
+    extends RTCPPacket
+{
+    public int ssrc;
+    public long ntptimestampmsw;
+    public long ntptimestamplsw;
+    public long rtptimestamp;
+    public long packetcount;
+    public long octetcount;
+    public RTCPReportBlock reports[];
+
+    public RTCPSRPacket(int ssrc, RTCPReportBlock reports[])
+    {
+        if (reports.length > 31)
+            throw new IllegalArgumentException("Too many reports");
+
+        this.ssrc = ssrc;
+        this.reports = reports;
+    }
+
+    RTCPSRPacket(RTCPPacket parent)
+    {
+        super(parent);
+        super.type = SR;
+    }
+
+    @Override
+    public void assemble(DataOutputStream out) throws IOException
+    {
+        out.writeByte(128 + reports.length);
+        out.writeByte(SR);
+        out.writeShort(6 + reports.length * 6);
+        out.writeInt(ssrc);
+        out.writeInt((int) ntptimestampmsw);
+        out.writeInt((int) ntptimestamplsw);
+        out.writeInt((int) rtptimestamp);
+        out.writeInt((int) packetcount);
+        out.writeInt((int) octetcount);
+        for (int i = 0; i < reports.length; i++)
+        {
+            out.writeInt(reports[i].ssrc);
+            out.writeInt((reports[i].packetslost & 0xffffff)
+                    + (reports[i].fractionlost << 24));
+            out.writeInt((int) reports[i].lastseq);
+            out.writeInt(reports[i].jitter);
+            out.writeInt((int) reports[i].lsr);
+            out.writeInt((int) reports[i].dlsr);
+        }
+    }
+
+    @Override
+    public int calcLength()
+    {
+        return 28 + reports.length * 24;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "\tRTCP SR (sender report) packet for sync source " + ssrc
+                + "\n\t\tNTP timestampMSW: " + ntptimestampmsw
+                + "\n\t\tNTP timestampLSW: " + ntptimestamplsw
+                + "\n\t\tRTP timestamp: " + rtptimestamp
+                + "\n\t\tnumber of packets sent: " + packetcount
+                + "\n\t\tnumber of octets (bytes) sent: " + octetcount + "\n"
+                + RTCPReportBlock.toString(reports);
+    }
+}
+

--- a/src/org/jitsi/impl/neomedia/rtcp/fmj_port/RTCPSenderInfo.java
+++ b/src/org/jitsi/impl/neomedia/rtcp/fmj_port/RTCPSenderInfo.java
@@ -1,0 +1,178 @@
+package org.jitsi.impl.neomedia.rtcp.fmj_port;
+
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.io.IOException;
+
+/**
+ * NOTE(brian): was net.sf.fmj.media.rtp.RTCPSenderInfo
+ */
+public class RTCPSenderInfo
+{
+    /**
+     * The size of the sender info
+     */
+    public static final int SIZE = 20;
+
+    // baseline NTP time if bit-0=0 -> 7-Feb-2036 @ 06:28:16 UTC
+    private static final long MSB_0_BASE_TIME = 2085978496000L;
+
+    // baseline NTP time if bit-0=1 -> 1-Jan-1900 @ 01:00:00 UTC
+    public static final long MSB_1_BASE_TIME = -2208988800000L;
+
+    // The Most Significant word of the timestamp
+    private long ntpTimestampMSW = 0;
+
+    // The Least Significant word of the timestamp
+    private long ntpTimestampLSW = 0;
+
+    // The RTP timestamp
+    private long rtpTimestamp = 0;
+
+    // The packet count
+    private long packetCount = 0;
+
+    // The octet count
+    private long octetCount = 0;
+
+    /**
+     * Parses an RTCP Sender Report (SR) packet
+     *
+     * @param offset
+     *            offset after which the RTCP SR starts
+     * @param length
+     *            length of the packet
+     * @param rtcpPacket
+     *            The data of the RTCP packet
+     * @throws IOException
+     *             I/O Exception
+     */
+    public RTCPSenderInfo(byte[] rtcpPacket, int offset, int length)
+            throws IOException
+    {
+        DataInputStream stream = new DataInputStream(new ByteArrayInputStream(
+                rtcpPacket, offset, length));
+        ntpTimestampMSW = stream.readInt() & RTPHeader.UINT_TO_LONG_CONVERT;
+        ntpTimestampLSW = stream.readInt() & RTPHeader.UINT_TO_LONG_CONVERT;
+        rtpTimestamp = stream.readInt() & RTPHeader.UINT_TO_LONG_CONVERT;
+        packetCount = stream.readInt() & RTPHeader.UINT_TO_LONG_CONVERT;
+        octetCount = stream.readInt() & RTPHeader.UINT_TO_LONG_CONVERT;
+    }
+
+    /**
+     * Returns the timestamp least significant word
+     *
+     * @return the timestamp's least significant word
+     */
+    public long getNtpTimestampLSW()
+    {
+        return ntpTimestampLSW;
+    }
+
+    /**
+     * Returns the timestamp most significant word
+     *
+     * @return the timestamp's most significant word
+     */
+    public long getNtpTimestampMSW()
+    {
+        return ntpTimestampMSW;
+    }
+
+    /**
+     * Returns the timestamp value in seconds
+     *
+     * @return timestamp in seconds
+     */
+    public double getNtpTimestampSecs()
+    {
+        return (double) getTimestamp() / 1000;
+    }
+
+    /**
+     * Returns the octet (cumulative) count. The total number of payload octets
+     * (i.e., not including header or padding) transmitted in RTP data packets
+     * by the sender since starting transmission up until the time this SR
+     * packet was generated. This field can be used to estimate the average
+     * payload data rate.
+     *
+     * @return the number of bytes sent until now
+     */
+    public long getOctetCount()
+    {
+        return octetCount;
+    }
+
+    /**
+     * Returns the packet (cumulative) count. The total number of RTP data
+     * packets transmitted by the sender since starting transmission up until
+     * the time this SR packet was generated.
+     *
+     * @return the number of packets sent until now
+     */
+    public long getPacketCount()
+    {
+        return packetCount;
+    }
+
+    /**
+     * Returns the RTP timestamp of this SR packet
+     *
+     * @return the timestamp of this RTCP packet
+     */
+    public long getRtpTimestamp()
+    {
+        return rtpTimestamp;
+    }
+
+    /**
+     * Returns the timestamp of the information
+     *
+     * @return timestamp of this information
+     */
+    public long getTimestamp()
+    {
+        long seconds = ntpTimestampMSW;
+        long fraction = ntpTimestampLSW;
+
+        // Use round-off on fractional part to preserve going to lower precision
+        fraction = Math.round(1000D * fraction / 0x100000000L);
+
+        /*
+         * If the most significant bit (MSB) on the seconds field is set we use
+         * a different time base. The following text is a quote from RFC-2030
+         * (SNTP v4):
+         *
+         * If bit 0 is set, the UTC time is in the range 1968-2036 and UTC time
+         * is reckoned from 0h 0m 0s UTC on 1 January 1900. If bit 0 is not set,
+         * the time is in the range 2036-2104 and UTC time is reckoned from 6h
+         * 28m 16s UTC on 7 February 2036.
+         */
+        long msb = seconds & 0x80000000L;
+        if (msb == 0)
+        {
+            // use base: 7-Feb-2036 @ 06:28:16 UTC
+            return MSB_0_BASE_TIME + (seconds * 1000) + fraction;
+        }
+        // use base: 1-Jan-1900 @ 01:00:00 UTC
+        return MSB_1_BASE_TIME + (seconds * 1000) + fraction;
+    }
+
+    /**
+     * Returns a String reprensenting the information about the RTCP sender
+     *
+     * @return a String representing this object
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString()
+    {
+        String buf = "";
+        buf += "ntp_ts=" + getNtpTimestampMSW();
+        buf += " " + getNtpTimestampLSW();
+        buf += " rtp_ts=" + getRtpTimestamp();
+        buf += " packet_ct=" + getPacketCount();
+        buf += " octect_ct=" + getOctetCount();
+        return buf;
+    }
+}

--- a/src/org/jitsi/impl/neomedia/rtcp/fmj_port/RTCPSenderReport.java
+++ b/src/org/jitsi/impl/neomedia/rtcp/fmj_port/RTCPSenderReport.java
@@ -1,0 +1,126 @@
+package org.jitsi.impl.neomedia.rtcp.fmj_port;
+
+import net.sf.fmj.media.rtp.RTCPSenderInfo;
+
+import javax.media.rtp.RTPStream;
+import java.io.IOException;
+
+/**
+ * NOTE(brian): was net.sf.fmj.media.rtp.RTCPSenderReport
+ */
+public class RTCPSenderReport
+    extends RTCPReport
+    implements SenderReport
+{
+    // The sender information
+    RTCPSenderInfo senderInformation = null;
+
+    // The RTPStream associated with the sender
+    private RTPStream stream = null;
+
+    /**
+     * Creates a new RTCPSenderReport
+     *
+     * @param data
+     *            The data of the report
+     * @param offset
+     *            The offset of the report in the data
+     * @param length
+     *            The length of the data
+     * @throws IOException
+     *             I/O Exception
+     */
+    public RTCPSenderReport(byte data[], int offset, int length)
+            throws IOException
+    {
+        super(data, offset, length);
+
+        senderInformation
+                = new RTCPSenderInfo(
+                data,
+                offset + RTCPHeader.SIZE,
+                length - RTCPHeader.SIZE);
+    }
+
+    /**
+     * Returns the sender's timestamp's least significant word.
+     *
+     * @return the sender's timestamp's least significant word
+     */
+    public long getNTPTimeStampLSW()
+    {
+        return senderInformation.getNtpTimestampLSW();
+    }
+
+    /**
+     * Returns the sender's timestamp's most significant word.
+     *
+     * @return the sender's timestamp's most significant word
+     */
+    public long getNTPTimeStampMSW()
+    {
+        return senderInformation.getNtpTimestampMSW();
+    }
+
+    /**
+     * Returns the RTP timestamp.
+     *
+     * @return the RTP timestamp
+     */
+    public long getRTPTimeStamp()
+    {
+        return senderInformation.getRtpTimestamp();
+    }
+
+    /**
+     * Returns the number of bytes sent by this sender.
+     *
+     * @return the number of bytes sent by this sender
+     */
+    public long getSenderByteCount()
+    {
+        return senderInformation.getOctetCount();
+    }
+
+    /**
+     * Returns the sender's feedbacks.
+     *
+     * @return the sender's feedbacks
+     */
+    public Feedback getSenderFeedback()
+    {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    /**
+     * Returns the number of packets sent by this sender.
+     *
+     * @return the number of packets sent by this sender
+     */
+    public long getSenderPacketCount()
+    {
+        return senderInformation.getPacketCount();
+    }
+
+    /**
+     * Returns the RTPStream associated with the sender.
+     *
+     * @return the RTPStream associated with the sender
+     */
+    public RTPStream getStream()
+    {
+        return stream;
+    }
+
+    /**
+     * Sets the RTPStream associated with the sender.
+     *
+     * @param stream
+     *            the RTPStream associated with the sender
+     */
+    protected void setStream(RTPStream stream)
+    {
+        this.stream = stream;
+    }
+}

--- a/src/org/jitsi/impl/neomedia/rtcp/fmj_port/RTPHeader.java
+++ b/src/org/jitsi/impl/neomedia/rtcp/fmj_port/RTPHeader.java
@@ -1,0 +1,215 @@
+package org.jitsi.impl.neomedia.rtcp.fmj_port;
+
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.net.DatagramPacket;
+
+/**
+ * NOTE(brian): was net.sf.fmj.media.rtp.RTPHeader
+ */
+public class RTPHeader
+{
+    /**
+     * The current RTP Header Version
+     */
+    public static final int VERSION = 2;
+
+    /**
+     * The maximum payload type
+     */
+    public static final int MAX_PAYLOAD = 127;
+
+    /**
+     * The size of the RTP Header
+     */
+    public static final int SIZE = 12;
+
+    /**
+     * The maximum RTP sequence
+     */
+    public static final int MAX_SEQUENCE = 65535;
+
+    /**
+     * Unsigned int to long conversion mask
+     */
+    public static final long UINT_TO_LONG_CONVERT = 0x00000000ffffffffL;
+
+    // Header bit masks and shifts
+    private static final int VERSION_MASK = 0xc000;
+
+    private static final int VERSION_SHIFT = 14;
+
+    private static final int PADDING_MASK = 0x2000;
+
+    private static final int PADDING_SHIFT = 13;
+
+    private static final int EXTENSION_MASK = 0x1000;
+
+    private static final int EXTENSION_SHIFT = 12;
+
+    private static final int CSRC_MASK = 0x0f00;
+
+    private static final int CSRC_SHIFT = 8;
+
+    private static final int MARKER_MASK = 0x0080;
+
+    private static final int MARKER_SHIFT = 7;
+
+    private static final int TYPE_MASK = 0x007f;
+
+    private static final int TYPE_SHIFT = 0;
+
+    // The first 16 bits of the header
+    private int flags;
+
+    // The second 16 bits of the header
+    private int sequence;
+
+    // The third and fourth 16 bits of the header
+    private long timestamp;
+
+    // The fifth and sixth 16 bits of the header
+    private long ssrc;
+
+    /**
+     * Creates a new RTPHeader
+     *
+     * @param offset
+     *            the offset after which the header starts
+     * @param length
+     *            the total length
+     * @param data
+     *            The packet to parse the header from
+     * @throws IOException
+     *             I/O Exception
+     */
+    public RTPHeader(byte[] data, int offset, int length) throws IOException
+    {
+        DataInputStream stream = new DataInputStream(new ByteArrayInputStream(
+                data, offset, length));
+
+        // Read the header values
+        this.flags = stream.readUnsignedShort();
+        this.sequence = stream.readUnsignedShort();
+        this.timestamp = stream.readInt() & UINT_TO_LONG_CONVERT;
+        this.ssrc = stream.readInt() & UINT_TO_LONG_CONVERT;
+
+        if (getVersion() != VERSION)
+        {
+            throw new IOException("Invalid Version");
+        }
+    }
+
+    /**
+     * Creates a new RTPHeader
+     *
+     * @param packet
+     *            The packet to parse the header from
+     * @throws IOException
+     *             I/O Exception
+     */
+    public RTPHeader(DatagramPacket packet) throws IOException
+    {
+        this(packet.getData(), packet.getOffset(), packet.getLength());
+    }
+
+    /**
+     * @return A count of Csrcs in the packet
+     */
+    short getCsrcCount()
+    {
+        return (short) ((getFlags() & CSRC_MASK) >> CSRC_SHIFT);
+    }
+
+    /**
+     * @return Any extension to the header
+     */
+    short getExtension()
+    {
+        return (short) ((getFlags() & EXTENSION_MASK) >> EXTENSION_SHIFT);
+    }
+
+    /**
+     * Returns the flags of the header
+     *
+     * @return The flags of the header
+     */
+    public int getFlags()
+    {
+        return flags;
+    }
+
+    /**
+     * @return The marker of the packet
+     */
+    short getMarker()
+    {
+        return (short) ((getFlags() & MARKER_MASK) >> MARKER_SHIFT);
+    }
+
+    /**
+     * @return The type of the data in the packet
+     */
+    short getPacketType()
+    {
+        return (short) ((getFlags() & TYPE_MASK) >> TYPE_SHIFT);
+    }
+
+    /**
+     * @return The padding in the data of the packet
+     */
+    short getPadding()
+    {
+        return (short) ((getFlags() & PADDING_MASK) >> PADDING_SHIFT);
+    }
+
+    /**
+     * @return The sequence number of the packet
+     */
+    int getSequence()
+    {
+        return sequence;
+    }
+
+    int getSize()
+    {
+        return SIZE + (getCsrcCount() * 4);
+    }
+
+    /**
+     * @return The ssrc of the data source
+     */
+    long getSsrc()
+    {
+        return ssrc;
+    }
+
+    /**
+     * @return The timestamp of the packet
+     */
+    long getTimestamp()
+    {
+        return timestamp;
+    }
+
+    /**
+     * @return The RTP version implemented
+     */
+    short getVersion()
+    {
+        return (short) ((getFlags() & VERSION_MASK) >> VERSION_SHIFT);
+    }
+
+    /**
+     * Prints the header
+     *
+     */
+    public void print()
+    {
+        System.err.println(getVersion() + "|" + getPadding() + "|"
+                + getExtension() + "|" + getCsrcCount() + "|" + getMarker()
+                + "|" + getPacketType() + "|" + getSequence() + "|"
+                + getTimestamp() + "|" + getSsrc());
+    }
+}

--- a/src/org/jitsi/impl/neomedia/rtcp/fmj_port/RTPParticipant.java
+++ b/src/org/jitsi/impl/neomedia/rtcp/fmj_port/RTPParticipant.java
@@ -1,0 +1,198 @@
+package org.jitsi.impl.neomedia.rtcp.fmj_port;
+
+import javax.media.rtp.RTPStream;
+import java.util.HashMap;
+import java.util.Vector;
+
+/**
+ * NOTE(brian): was net.sf.fmj.media.rtp.RTPParticipant
+ */
+public class RTPParticipant
+    implements Participant
+{
+    // The streams of the participant
+    private Vector streams = new Vector();
+
+    // The RTCP reports of the participant
+    private HashMap rtcpReports = new HashMap();
+
+    // The CNAME of the particpant
+    private String cName = "";
+
+    // A vector of source description objects
+    protected HashMap sourceDescriptions = new HashMap();
+
+    // True if the participant is active
+    private boolean active = false;
+
+    // The size of the sdes elements combined in SDES format
+    private int sdesSize = 0;
+
+    // Time on which the last report from this participant was received
+    // We set it to the current to avoid getting directly timed out
+    protected long lastReportTime = System.currentTimeMillis();
+
+    /**
+     * Creates a new RTPParticipant
+     *
+     * @param cName
+     *            the RTP CNAME of this participant.
+     */
+    public RTPParticipant(String cName)
+    {
+        this.cName = cName;
+        addSourceDescription(new SourceDescription(
+                SourceDescription.SOURCE_DESC_CNAME, cName, 1, false));
+        addSourceDescription(new SourceDescription(
+                SourceDescription.SOURCE_DESC_NAME, cName, 1, false));
+    }
+
+    /**
+     * Adds an RTCP Report for this participant
+     *
+     * @param report
+     *            The report to add
+     */
+    public void addReport(javax.media.rtp.rtcp.Report report)
+    {
+        lastReportTime = System.currentTimeMillis();
+        rtcpReports.put(new Long(report.getSSRC()), report);
+        Vector sdes = report.getSourceDescription();
+        for (int i = 0; i < sdes.size(); i++)
+        {
+            addSourceDescription((SourceDescription) sdes.get(i));
+        }
+
+        if ((streams.size() == 0) && (report instanceof RTCPReport))
+        {
+            ((RTCPReport) report).sourceDescriptions = new Vector(
+                    sourceDescriptions.values());
+        }
+    }
+
+    /**
+     * Adds a source description item to the participant
+     *
+     * @param sdes
+     *            The SDES item to add
+     */
+    protected void addSourceDescription(SourceDescription sdes)
+    {
+        SourceDescription oldSdes = (SourceDescription) sourceDescriptions
+                .get(new Integer(sdes.getType()));
+        if (oldSdes != null)
+        {
+            sdesSize -= oldSdes.getDescription().length();
+            sdesSize -= 2;
+        }
+        sourceDescriptions.put(new Integer(sdes.getType()), sdes);
+        sdesSize += 2;
+        sdesSize += sdes.getDescription().length();
+    }
+
+    /**
+     * Adds a stream to the participant
+     *
+     * @param stream
+     *            stream to associate with this participant
+     */
+    protected void addStream(RTPStream stream)
+    {
+        streams.add(stream);
+    }
+
+    /**
+     * Returns this participant's RTP CNAME.
+     *
+     * @return this participant's RTP CNAME
+     */
+    public String getCNAME()
+    {
+        return cName;
+    }
+
+    /**
+     * Returns this participant's last report time, which is the last time he's
+     * sent us a report.
+     *
+     * @return the participant's last report time
+     */
+    public long getLastReportTime()
+    {
+        return lastReportTime;
+    }
+
+    /**
+     * Returns the reports associated with this participant.
+     *
+     * @return the reports associated with this participant
+     */
+    public Vector getReports()
+    {
+        return new Vector(rtcpReports.values());
+    }
+
+    /**
+     * Returns the number of bytes of sdes that this participant requires.
+     *
+     * @return the number of bytes of sdes that this participant requires
+     */
+    public int getSdesSize()
+    {
+        return sdesSize;
+    }
+
+    /**
+     * Returns the sources descriptions (SDES) associated with this participant.
+     *
+     * @return the sources descriptions (SDES) associated with this participant
+     */
+    public Vector getSourceDescription()
+    {
+        return new Vector(sourceDescriptions.values());
+    }
+
+    /**
+     * Returns the streams associated with this participant.
+     *
+     * @return the streams associated with this participant
+     */
+    public Vector getStreams()
+    {
+        return streams;
+    }
+
+    /**
+     * Returns true if the participant is active
+     *
+     * @return true if the participant is active
+     */
+    public boolean isActive()
+    {
+        return active;
+    }
+
+    /**
+     * Removes the specified stream from this participant's associated streams
+     * list.
+     *
+     * @param stream
+     *            the stream to erase
+     */
+    protected void removeStream(RTPStream stream)
+    {
+        streams.remove(stream);
+    }
+
+    /**
+     * Sets the participant active or inactive
+     *
+     * @param active
+     *            Activity of the participant, true if active
+     */
+    protected void setActive(boolean active)
+    {
+        this.active = active;
+    }
+
+}

--- a/src/org/jitsi/impl/neomedia/rtcp/fmj_port/RTPStats.java
+++ b/src/org/jitsi/impl/neomedia/rtcp/fmj_port/RTPStats.java
@@ -1,0 +1,197 @@
+package org.jitsi.impl.neomedia.rtcp.fmj_port;
+
+import javax.media.rtp.ReceptionStats;
+
+/**
+ * NOTE(brian): was net.sf.fmj.media.rtp.RTPStats
+ */
+public class RTPStats
+    implements ReceptionStats
+{
+    public static final int PDULOST = 0;
+    public static final int PDUPROCSD = 1;
+    public static final int PDUMISORD = 2;
+    public static final int PDUINVALID = 3;
+    public static final int PDUDUP = 4;
+    public static final int PAYLOAD = 5;
+    public static final int ENCODE = 6;
+    public static final int QSIZE = 7;
+    public static final int PDUDROP = 8;
+    public static final int ADUDROP = 9;
+    private int numLost;
+    private int numProc;
+    private int numMisord;
+    private int numInvalid;
+    private int numDup;
+    private int payload;
+    private String encodeName;
+    private int qSize;
+    private int PDUDrop;
+    private int ADUDrop;
+
+    /**
+     * The burst characteristics/metrics and the algorithm for measuring them.
+     */
+    private final BurstMetrics burstMetrics = new BurstMetrics();
+
+    public RTPStats()
+    {
+        numLost = 0;
+        numProc = 0;
+        numMisord = 0;
+        numInvalid = 0;
+        numDup = 0;
+        qSize = 0;
+        PDUDrop = 0;
+        ADUDrop = 0;
+    }
+
+    public int getADUDrop()
+    {
+        return ADUDrop;
+    }
+
+    public int getBufferSize()
+    {
+        return qSize;
+    }
+
+    public String getEncodingName()
+    {
+        return encodeName;
+    }
+
+    public int getPayloadType()
+    {
+        return payload;
+    }
+
+    public int getPDUDrop()
+    {
+        return PDUDrop;
+    }
+
+    public int getPDUDuplicate()
+    {
+        return numDup;
+    }
+
+    public int getPDUInvalid()
+    {
+        return numInvalid;
+    }
+
+    public int getPDUlost()
+    {
+        return numLost;
+    }
+
+    public int getPDUMisOrd()
+    {
+        return numMisord;
+    }
+
+    public int getPDUProcessed()
+    {
+        return numProc;
+    }
+
+    @Override
+    public String toString()
+    {
+        String s = "PDULost " + getPDUlost() + "\nPDUProcessed "
+                + getPDUProcessed() + "\nPDUMisord " + getPDUMisOrd()
+                + "\nPDUInvalid " + getPDUInvalid() + "\nPDUDuplicate "
+                + getPDUDuplicate();
+        return s;
+    }
+
+    public synchronized void update(int which)
+    {
+        switch (which)
+        {
+            case PDULOST:
+                numLost++;
+                getBurstMetrics().update(which);
+                break;
+
+            case PDUPROCSD:
+                numProc++;
+                getBurstMetrics().update(which);
+                break;
+
+            case PDUMISORD:
+                numMisord++;
+                break;
+
+            case PDUINVALID:
+                numInvalid++;
+                break;
+
+            case PDUDUP:
+                numDup++;
+                break;
+
+            case PDUDROP:
+                PDUDrop++;
+                getBurstMetrics().update(which);
+                break;
+        }
+    }
+
+    public synchronized void update(int which, int amount)
+    {
+        switch (which)
+        {
+            case PDULOST:
+                if (amount > 0)
+                {
+                /*
+                 * The incrementing of PDULOST is already handled by the method
+                 * update(int). Do not duplicate the source code for the sake of
+                 * maintenance.
+                 */
+                    while (amount-- > 0) update(which);
+                }
+                else
+                {
+                    numLost += amount;
+                }
+                break;
+
+            case PAYLOAD:
+                payload = amount;
+                break;
+
+            case QSIZE:
+                qSize = amount;
+                break;
+
+            case PDUDROP:
+                PDUDrop = amount;
+                break;
+
+            case ADUDROP:
+                ADUDrop = amount;
+                break;
+        }
+    }
+
+    public synchronized void update(int which, String name)
+    {
+        if (which == ENCODE)
+            encodeName = name;
+    }
+
+    /**
+     * Gets the burst characteristics/metrics and the algorithm for measuring
+     * them.
+     *
+     * @return the burst characteristics/metrics and the algorithm for measuring
+     * them
+     */
+    public BurstMetrics getBurstMetrics()
+    {
+        return burstMetrics;
+    }
+}

--- a/src/org/jitsi/impl/neomedia/rtcp/fmj_port/ReceiverReport.java
+++ b/src/org/jitsi/impl/neomedia/rtcp/fmj_port/ReceiverReport.java
@@ -1,0 +1,9 @@
+package org.jitsi.impl.neomedia.rtcp.fmj_port;
+
+/**
+ * NOTE(brian): was javax.media.rtp.rtcp.ReceiverReport
+ */
+public interface ReceiverReport extends Report
+{
+    // No additional methods.
+}

--- a/src/org/jitsi/impl/neomedia/rtcp/fmj_port/Report.java
+++ b/src/org/jitsi/impl/neomedia/rtcp/fmj_port/Report.java
@@ -1,0 +1,17 @@
+package org.jitsi.impl.neomedia.rtcp.fmj_port;
+
+import java.util.Vector;
+
+/**
+ * NOTE(brian): was javax.media.rtp.rtcp.Report
+ */
+public interface Report
+{
+    public Vector getFeedbackReports();
+
+    public Participant getParticipant();
+
+    public Vector getSourceDescription();
+
+    public long getSSRC();
+}

--- a/src/org/jitsi/impl/neomedia/rtcp/fmj_port/SenderReport.java
+++ b/src/org/jitsi/impl/neomedia/rtcp/fmj_port/SenderReport.java
@@ -1,0 +1,24 @@
+package org.jitsi.impl.neomedia.rtcp.fmj_port;
+
+import javax.media.rtp.RTPStream;
+
+/**
+ * NOTE(brian): was javax.media.rtp.rtcp.SenderReport
+ */
+public interface SenderReport extends Report
+{
+    public long getNTPTimeStampLSW();
+
+    public long getNTPTimeStampMSW();
+
+    public long getRTPTimeStamp();
+
+    public long getSenderByteCount();
+
+    public Feedback getSenderFeedback();
+
+    public long getSenderPacketCount();
+
+    public RTPStream getStream();
+}
+

--- a/src/org/jitsi/impl/neomedia/rtcp/fmj_port/SourceDescription.java
+++ b/src/org/jitsi/impl/neomedia/rtcp/fmj_port/SourceDescription.java
@@ -1,0 +1,84 @@
+package org.jitsi.impl.neomedia.rtcp.fmj_port;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+/**
+ * NOTE(brian): was javax.media.rtp.rtcp.SourceDescription
+ */
+public class SourceDescription implements java.io.Serializable
+{
+    public static final int SOURCE_DESC_CNAME = 1;
+
+    public static final int SOURCE_DESC_NAME = 2;
+
+    public static final int SOURCE_DESC_EMAIL = 3;
+
+    public static final int SOURCE_DESC_PHONE = 4;
+
+    public static final int SOURCE_DESC_LOC = 5;
+
+    public static final int SOURCE_DESC_TOOL = 6;
+
+    public static final int SOURCE_DESC_NOTE = 7;
+
+    public static final int SOURCE_DESC_PRIV = 8;
+
+    public static String generateCNAME()
+    {
+        // generates something like user@host
+        final String hostname;
+        try
+        {
+            hostname = InetAddress.getLocalHost().getHostName();
+        } catch (UnknownHostException e)
+        {
+            throw new RuntimeException(e);
+        }
+
+        return System.getProperty("user.name") + '@' + hostname;
+
+    }
+
+    private int type;
+
+    private String description;
+
+    private int frequency;
+
+    private boolean encrypted;
+
+    public SourceDescription(int type, String description, int frequency,
+                             boolean encrypted)
+    {
+        this.type = type;
+        this.description = description;
+        this.frequency = frequency;
+        this.encrypted = encrypted;
+    }
+
+    public String getDescription()
+    {
+        return description;
+    }
+
+    public boolean getEncrypted()
+    {
+        return encrypted;
+    }
+
+    public int getFrequency()
+    {
+        return frequency;
+    }
+
+    public int getType()
+    {
+        return type;
+    }
+
+    public void setDescription(String desc)
+    {
+        this.description = desc;
+    }
+}

--- a/src/org/jitsi/impl/neomedia/rtcp/fmj_port/UDPPacket.java
+++ b/src/org/jitsi/impl/neomedia/rtcp/fmj_port/UDPPacket.java
@@ -1,0 +1,28 @@
+package org.jitsi.impl.neomedia.rtcp.fmj_port;
+
+import java.net.DatagramPacket;
+import java.net.InetAddress;
+import java.util.Date;
+
+/**
+ * NOTE(brian): was net.sf.fmj.media.rtp.util.UDPPacket
+ */
+public class UDPPacket
+    extends Packet
+{
+    public DatagramPacket datagrampacket;
+    public int localPort;
+    public int remotePort;
+    public InetAddress remoteAddress;
+
+    @Override
+    public String toString()
+    {
+        String s = "UDP Packet of size " + super.length;
+        if (super.received)
+            s = s + " received at " + new Date(super.receiptTime) + " on port "
+                    + localPort + " from " + remoteAddress + " port "
+                    + remotePort;
+        return s;
+    }
+}

--- a/src/org/jitsi/impl/neomedia/rtp/RTCPPacketListenerAdapter.java
+++ b/src/org/jitsi/impl/neomedia/rtp/RTCPPacketListenerAdapter.java
@@ -15,8 +15,8 @@
  */
 package org.jitsi.impl.neomedia.rtp;
 
-import net.sf.fmj.media.rtp.*;
 import org.jitsi.impl.neomedia.rtcp.*;
+import org.jitsi.impl.neomedia.rtcp.fmj_port.*;
 import org.jitsi.service.neomedia.rtp.*;
 
 /**

--- a/src/org/jitsi/impl/neomedia/rtp/sendsidebandwidthestimation/BandwidthEstimatorImpl.java
+++ b/src/org/jitsi/impl/neomedia/rtp/sendsidebandwidthestimation/BandwidthEstimatorImpl.java
@@ -15,7 +15,7 @@
  */
 package org.jitsi.impl.neomedia.rtp.sendsidebandwidthestimation;
 
-import net.sf.fmj.media.rtp.*;
+import org.jitsi.impl.neomedia.rtcp.fmj_port.*;
 import org.jitsi.service.configuration.*;
 import org.jitsi.service.libjitsi.*;
 import org.jitsi.service.neomedia.*;

--- a/src/org/jitsi/impl/neomedia/transform/rtcp/StatisticsEngine.java
+++ b/src/org/jitsi/impl/neomedia/transform/rtcp/StatisticsEngine.java
@@ -21,12 +21,11 @@ import java.util.*;
 import javax.media.control.*;
 import javax.media.rtp.*;
 
-import net.sf.fmj.media.rtp.*;
-import net.sf.fmj.media.rtp.util.*;
-
+import net.sf.fmj.media.rtp.SSRCInfo;
 import org.jitsi.impl.neomedia.*;
 import org.jitsi.impl.neomedia.device.*;
 import org.jitsi.impl.neomedia.rtcp.*;
+import org.jitsi.impl.neomedia.rtcp.fmj_port.*;
 import org.jitsi.impl.neomedia.stats.*;
 import org.jitsi.impl.neomedia.transform.*;
 import org.jitsi.service.neomedia.*;

--- a/src/org/jitsi/service/neomedia/rtp/RTCPExtendedReport.java
+++ b/src/org/jitsi/service/neomedia/rtp/RTCPExtendedReport.java
@@ -15,10 +15,10 @@
  */
 package org.jitsi.service.neomedia.rtp;
 
+import org.jitsi.impl.neomedia.rtcp.fmj_port.*;
+
 import java.io.*;
 import java.util.*;
-
-import net.sf.fmj.media.rtp.*;
 
 /**
  * Represents an RTP Control Protocol Extended Report (RTCP XR) packet in the

--- a/src/org/jitsi/service/neomedia/rtp/RTCPPacketListener.java
+++ b/src/org/jitsi/service/neomedia/rtp/RTCPPacketListener.java
@@ -15,8 +15,8 @@
  */
 package org.jitsi.service.neomedia.rtp;
 
-import net.sf.fmj.media.rtp.*;
 import org.jitsi.impl.neomedia.rtcp.*;
+import org.jitsi.impl.neomedia.rtcp.fmj_port.*;
 
 /**
  * A simple interface that enables listening for RTCP packets.

--- a/src/org/jitsi/service/neomedia/rtp/RTCPReportAdapter.java
+++ b/src/org/jitsi/service/neomedia/rtp/RTCPReportAdapter.java
@@ -15,7 +15,7 @@
  */
 package org.jitsi.service.neomedia.rtp;
 
-import net.sf.fmj.media.rtp.*;
+import org.jitsi.impl.neomedia.rtcp.fmj_port.*;
 
 /**
  * A default implementation of <tt>RTCPReportListener</tt> to facilitate

--- a/src/org/jitsi/service/neomedia/rtp/RTCPReportListener.java
+++ b/src/org/jitsi/service/neomedia/rtp/RTCPReportListener.java
@@ -15,7 +15,7 @@
  */
 package org.jitsi.service.neomedia.rtp;
 
-import net.sf.fmj.media.rtp.*;
+import org.jitsi.impl.neomedia.rtcp.fmj_port.*;
 
 /**
  *

--- a/src/org/jitsi/service/neomedia/rtp/RTCPReports.java
+++ b/src/org/jitsi/service/neomedia/rtp/RTCPReports.java
@@ -17,8 +17,7 @@ package org.jitsi.service.neomedia.rtp;
 
 import java.util.*;
 
-import net.sf.fmj.media.rtp.*;
-
+import org.jitsi.impl.neomedia.rtcp.fmj_port.*;
 import org.jitsi.util.*;
 
 /**

--- a/src/org/jitsi/util/ByteBufferOutputStream.java
+++ b/src/org/jitsi/util/ByteBufferOutputStream.java
@@ -102,7 +102,7 @@ public class ByteBufferOutputStream
         if (index >= endIndex)
         {
             throw new IOException(
-                "This " + net.sf.fmj.utility.ByteBufferOutputStream.class.getName()
+                "This " + ByteBufferOutputStream.class.getName()
                     + " is fully written.");
         }
         else

--- a/src/org/jitsi/util/function/RTCPGenerator.java
+++ b/src/org/jitsi/util/function/RTCPGenerator.java
@@ -15,7 +15,7 @@
  */
 package org.jitsi.util.function;
 
-import net.sf.fmj.media.rtp.*;
+import org.jitsi.impl.neomedia.rtcp.fmj_port.*;
 import org.jitsi.service.neomedia.*;
 
 /**


### PR DESCRIPTION
focusing on `StatisticsEngine`, port over any classes from fmj into libjitsi.

a (small) jvb change was necessary to accommodate this as well which can be found here: https://github.com/bbaldino/jitsi-videobridge/tree/fmj_1