### PR TITLE
ref: Throw an exception instead of failing silently if the chunk type…

### DIFF
--- a/src/org/jitsi/impl/neomedia/rtcp/RTCPTCCPacket.java
+++ b/src/org/jitsi/impl/neomedia/rtcp/RTCPTCCPacket.java
@@ -337,7 +337,10 @@ public class RTCPTCCPacket
                 | (buf[off + 1] & 0xff);
         }
 
-        return -1;
+        // This should never happen.
+        throw new IllegalStateException(
+            "The one-bit chunk type is neither 0 nor 1. A superposition is "+
+                " not a valid chunk type.");
     }
 
     /**


### PR DESCRIPTION
… fails to be parsed.