### PR TITLE
WIP: Implements send-side bandwidth estimations.

### DIFF
--- a/src/org/jitsi/impl/neomedia/MediaStreamImpl.java
+++ b/src/org/jitsi/impl/neomedia/MediaStreamImpl.java
@@ -1434,6 +1434,16 @@ public class MediaStreamImpl
     }
 
     /**
+     * Gets the {@link TransportCCEngine} instance, if any, for this
+     * {@link MediaStream}. The instance could be shared between more than one
+     * {@link MediaStream}, if they all use the same transport.
+     */
+    public TransportCCEngine getTransportCCEngine()
+    {
+        return this.transportCCEngine;
+    }
+
+    /**
      * Returns the ID currently assigned to a specific RTP extension.
      *
      * @param rtpExtension the RTP extension to get the currently assigned ID of

--- a/src/org/jitsi/impl/neomedia/MediaStreamStatsImpl.java
+++ b/src/org/jitsi/impl/neomedia/MediaStreamStatsImpl.java
@@ -1230,6 +1230,16 @@ public class MediaStreamStatsImpl
                     remoteBitrateEstimator.onRttUpdate(
                         /* avgRttMs */ rttMs,
                         /* maxRttMs*/ rttMs);
+
+                    TransportCCEngine tccEngine
+                        = mediaStream.getTransportCCEngine();
+
+                    if (tccEngine != null)
+                    {
+                        tccEngine.onRttUpdate(
+                                /* avgRttMs */ rttMs,
+                                /* maxRttMs*/ rttMs);
+                    }
                 }
             }
         }

--- a/src/org/jitsi/impl/neomedia/rtcp/RTCPFBPacket.java
+++ b/src/org/jitsi/impl/neomedia/rtcp/RTCPFBPacket.java
@@ -61,11 +61,6 @@ public class RTCPFBPacket
      */
     public long sourceSSRC;
 
-    public RTCPFBPacket()
-    {
-
-    }
-
     public RTCPFBPacket(int fmt, int type, long senderSSRC, long sourceSSRC)
     {
         super.type = type;

--- a/src/org/jitsi/impl/neomedia/rtcp/RTCPReceiverFeedbackTermination.java
+++ b/src/org/jitsi/impl/neomedia/rtcp/RTCPReceiverFeedbackTermination.java
@@ -167,7 +167,7 @@ public class RTCPReceiverFeedbackTermination
             return -1;
         }
 
-        return stream.getStreamRTPManager().getLocalSSRC();
+        return streamRTPManager.getLocalSSRC();
     }
 
 

--- a/src/org/jitsi/impl/neomedia/rtcp/RTCPReceiverFeedbackTermination.java
+++ b/src/org/jitsi/impl/neomedia/rtcp/RTCPReceiverFeedbackTermination.java
@@ -415,6 +415,7 @@ public class RTCPReceiverFeedbackTermination
                         || RTCPTCCPacket.isTCCPacket(baf))
                 {
                     it.remove();
+                    continue;
                 }
 
                 if (!send)
@@ -431,6 +432,7 @@ public class RTCPReceiverFeedbackTermination
                             .requestKeyframe(source);
 
                         it.remove();
+                        continue;
                     }
                 }
             }

--- a/src/org/jitsi/impl/neomedia/rtcp/RTCPReceiverFeedbackTermination.java
+++ b/src/org/jitsi/impl/neomedia/rtcp/RTCPReceiverFeedbackTermination.java
@@ -410,7 +410,9 @@ public class RTCPReceiverFeedbackTermination
             {
                 ByteArrayBuffer baf = it.next();
                 int pt = RTCPHeaderUtils.getPacketType(baf);
-                if (pt == RTCPRRPacket.RR || RTCPREMBPacket.isREMBPacket(baf))
+                if (pt == RTCPRRPacket.RR
+                        || RTCPREMBPacket.isREMBPacket(baf)
+                        || RTCPTCCPacket.isTCCPacket(baf))
                 {
                     it.remove();
                 }

--- a/src/org/jitsi/impl/neomedia/rtcp/RTCPTCCPacket.java
+++ b/src/org/jitsi/impl/neomedia/rtcp/RTCPTCCPacket.java
@@ -90,6 +90,14 @@ public class RTCPTCCPacket
         return getPacketsFci(getFCI(baf));
     }
 
+    /**
+     * @return the reference time of the FCI buffer of an RTCP TCC packet.
+     *
+     * The format is 32 bits with 250µs resolution. Note that the format in the
+     * transport-wide cc draft is 24bit with 2^6ms resolution. The change in the
+     * unit facilitates the arrival time computations, as the deltas have 250µs
+     * resolution.
+     */
     public static long getReferenceTime(ByteArrayBuffer fciBuffer)
     {
         byte[] buf = fciBuffer.getBuffer();

--- a/src/org/jitsi/impl/neomedia/rtcp/RTCPTCCPacket.java
+++ b/src/org/jitsi/impl/neomedia/rtcp/RTCPTCCPacket.java
@@ -55,17 +55,18 @@ import java.util.*;
  * }</pre>
  *
  * @author Boris Grozev
+ * @author George Politis
  */
 public class RTCPTCCPacket
     extends RTCPFBPacket
 {
     /**
      * Gets a boolean indicating whether or not the RTCP packet specified in the
-     * {@link ByteArrayBuffer} that is passed as an argument is a NACK packet or
+     * {@link ByteArrayBuffer} that is passed as an argument is a TCC packet or
      * not.
      *
      * @param baf the {@link ByteArrayBuffer}
-     * @return true if the byte array buffer holds a NACK packet, otherwise
+     * @return true if the byte array buffer holds a TCC packet, otherwise
      * false.
      */
     public static boolean isTCCPacket(ByteArrayBuffer baf)
@@ -75,25 +76,50 @@ public class RTCPTCCPacket
     }
 
     /**
-     * Parses the FCI portion of an RTCP transport-cc feedback packet in the
-     * specified buffer.
+     * @return the packets represented in an RTCP transport-cc feedback packet.
      *
      * Warning: the timestamps are represented in the 250µs format used by the
      * on-the-wire format, and don't represent local time. This is different
      * than the timestamps expected as input when constructing a packet with
      * {@link RTCPTCCPacket#RTCPTCCPacket(long, long, PacketMap, byte)}.
      *
-     * @param tccPacket the {@link RTCPTCCPacket} that will hold the parsed FCI.
+     * @param baf the buffer which contains the RTCP packet.
+     */
+    public static PacketMap getPackets(ByteArrayBuffer baf)
+    {
+        return getPacketsFci(getFCI(baf));
+    }
+
+    public static long getReferenceTime(ByteArrayBuffer fciBuffer)
+    {
+        byte[] buf = fciBuffer.getBuffer();
+        int off = fciBuffer.getOffset();
+
+        // reference time. The 24 bit field uses increments of 2^6ms, and we
+        // shift by 8 to change the resolution to 250µs.
+        // FIXME this is supposed to be a signed int.
+        long referenceTime = RTPUtils.readUint24AsInt(buf, off + 4) << 8;
+
+        return referenceTime;
+    }
+
+    /**
+     * @return the packets represented in the FCI portion of an RTCP
+     * transport-cc feedback packet.
+     *
+     * Warning: the timestamps are represented in the 250µs format used by the
+     * on-the-wire format, and don't represent local time. This is different
+     * than the timestamps expected as input when constructing a packet with
+     * {@link RTCPTCCPacket#RTCPTCCPacket(long, long, PacketMap, byte)}.
+     *
      * @param fciBuffer the buffer which contains the FCI portion of the RTCP
      * feedback packet.
-     * @return true if parsing succeeded, false otherwise.
      */
-    public static boolean parseFci(
-        RTCPTCCPacket tccPacket, ByteArrayBuffer fciBuffer)
+    public static PacketMap getPacketsFci(ByteArrayBuffer fciBuffer)
     {
         if (fciBuffer == null)
         {
-            return false;
+            return null;
         }
 
         byte[] buf = fciBuffer.getBuffer();
@@ -103,18 +129,14 @@ public class RTCPTCCPacket
         if (len < MIN_FCI_LENGTH)
         {
             logger.warn(PARSE_ERROR + "length too small: " + len);
-            return false;
+            return null;
         }
 
         // The fixed fields
         int baseSeq = RTPUtils.readUint16AsInt(buf, off);
         int packetStatusCount = RTPUtils.readUint16AsInt(buf, off + 2);
 
-        // reference time. The 24 bit field uses increments of 2^6ms, and we
-        // shift by 8 to change the resolution to 250µs.
-        tccPacket.referenceTime = RTPUtils.readUint24AsInt(buf, off + 4) << 8;
-
-        long offsetUs = 0;
+        long referenceTime = getReferenceTime(fciBuffer);
 
         // The offset at which the packet status chunk list starts.
         int pscOff = off + 8;
@@ -126,7 +148,7 @@ public class RTCPTCCPacket
             if (pscOff + 2 > off + len)
             {
                 logger.warn(PARSE_ERROR + "reached the end while reading chunks");
-                return false;
+                return null;
             }
 
             int packetsInChunk = getPacketCount(buf, pscOff);
@@ -169,17 +191,17 @@ public class RTCPTCCPacket
                     {
                         logger.warn(PARSE_ERROR
                                 + "reached the end while reading delta.");
-                        return false;
+                        return null;
                     }
                     delta = buf[deltaOff++] & 0xff;
                     break;
                 case SYMBOL_LARGE_DELTA:
-                    // The delta is a 6-bit signed integer.
+                    // The delta is a 16-bit signed integer.
                     if (deltaOff + 1 >= off + len) // we're about to read 2 bytes
                     {
                         logger.warn(PARSE_ERROR
                                 + "reached the end while reading long delta.");
-                        return false;
+                        return null;
                     }
                     delta = RTPUtils.readInt16AsInt(buf, deltaOff);
                     deltaOff += 2;
@@ -196,11 +218,29 @@ public class RTCPTCCPacket
                     // but we push the packet in the map to indicate that it was
                     // marked as not received.
                     packets.put(baseSeq, NEGATIVE_ONE);
+                    if (logger.isDebugEnabled())
+                    {
+                        logger.debug("seq=" + baseSeq
+                                + ",reference_time=" + referenceTime
+                                + ",delta=" + -1
+                                + ",symbol=" + symbol);
+                    }
                 }
                 else
                 {
-                    offsetUs += delta;
-                    packets.put(baseSeq, offsetUs);
+                    // The draft is not clear about what the reference time for
+                    // each packet is. We adhere to the webrtc.org behavior so
+                    // that every packet for which there is a delta updates 
+                    // the reference (even if the delta is negative).
+                    if (logger.isDebugEnabled())
+                    {
+                        logger.debug("seq=" + baseSeq
+                                + ",reference_time=" + referenceTime
+                                + ",delta=" + delta
+                                + ",symbol=" + symbol);
+                    }
+                    referenceTime += delta;
+                    packets.put(baseSeq, referenceTime);
                 }
 
                 baseSeq = (baseSeq + 1) & 0xffff;
@@ -211,9 +251,7 @@ public class RTCPTCCPacket
             packetsRemaining -= packetsInChunk;
         }
 
-        tccPacket.packets = packets;
-
-        return true;
+        return packets;
     }
 
     /**
@@ -421,19 +459,6 @@ public class RTCPTCCPacket
     private PacketMap packets = null;
 
     /**
-     * The reference time of this TCC packet.
-     */
-    private long referenceTime = -1;
-
-    /**
-     * Ctor.
-     */
-    public RTCPTCCPacket()
-    {
-
-    }
-
-    /**
      * Initializes a new <tt>RTCPTCCPacket</tt> instance.
      * @param base
      */
@@ -622,20 +647,10 @@ public class RTCPTCCPacket
     {
         if (packets == null)
         {
-            parseFci(this, new ByteArrayBufferImpl(fci, 0, fci.length));
+            packets = getPacketsFci(new ByteArrayBufferImpl(fci, 0, fci.length));
         }
 
         return packets;
-    }
-
-    /**
-     * Gets the reference time of this TCC packet.
-     *
-     * @return the reference time of this TCC packet.
-     */
-    public long getReferenceTime()
-    {
-        return referenceTime;
     }
 
     /**

--- a/src/org/jitsi/impl/neomedia/rtp/TransportCCEngine.java
+++ b/src/org/jitsi/impl/neomedia/rtp/TransportCCEngine.java
@@ -384,16 +384,6 @@ public class TransportCCEngine
     @Override
     public void tccReceived(RTCPTCCPacket tccPacket)
     {
-        MediaStream videoStream = null;
-        for (MediaStream stream : mediaStreams)
-        {
-            if (stream instanceof VideoMediaStream)
-            {
-                videoStream = stream;
-                break;
-            }
-        }
-
         RTCPTCCPacket.PacketMap packetMap = tccPacket.getPackets();
         long previousArrivalTimeMs = -1;
         for (Map.Entry<Integer, Long> entry : packetMap.entrySet())
@@ -419,37 +409,39 @@ public class TransportCCEngine
                 packetDetail = sentPacketDetails.remove(entry.getKey());
             }
 
-            if (packetDetail != null && videoStream != null)
+            if (packetDetail == null)
             {
-                long arrivalTimeMs = arrivalTime250Us / 4
-                    - remoteReferenceTimeMs + localReferenceTimeMs;
-
-                if (logger.isDebugEnabled())
-                {
-                    if (previousArrivalTimeMs != -1)
-                    {
-                        long diff_ms = arrivalTimeMs - previousArrivalTimeMs;
-                        logger.debug("seq=" + entry.getKey()
-                                + ", arrival_time_ms=" + arrivalTimeMs
-                                + ", diff_ms=" + diff_ms);
-                    }
-                    else
-                    {
-                        logger.debug("seq=" + entry.getKey()
-                                + ", arrival_time_ms=" + arrivalTimeMs);
-                    }
-                }
-
-                previousArrivalTimeMs = arrivalTimeMs;
-                long sendTime24bits = RemoteBitrateEstimatorAbsSendTime
-                    .convertMsTo24Bits(packetDetail.packetSendTimeMs);
-
-                bitrateEstimatorAbsSendTime.incomingPacketInfo(
-                    arrivalTimeMs,
-                    sendTime24bits,
-                    packetDetail.packetLength,
-                    tccPacket.getSourceSSRC());
+                continue;
             }
+
+            long arrivalTimeMs = arrivalTime250Us / 4
+                - remoteReferenceTimeMs + localReferenceTimeMs;
+
+            if (logger.isDebugEnabled())
+            {
+                if (previousArrivalTimeMs != -1)
+                {
+                    long diff_ms = arrivalTimeMs - previousArrivalTimeMs;
+                    logger.debug("seq=" + entry.getKey()
+                            + ", arrival_time_ms=" + arrivalTimeMs
+                            + ", diff_ms=" + diff_ms);
+                }
+                else
+                {
+                    logger.debug("seq=" + entry.getKey()
+                            + ", arrival_time_ms=" + arrivalTimeMs);
+                }
+            }
+
+            previousArrivalTimeMs = arrivalTimeMs;
+            long sendTime24bits = RemoteBitrateEstimatorAbsSendTime
+                .convertMsTo24Bits(packetDetail.packetSendTimeMs);
+
+            bitrateEstimatorAbsSendTime.incomingPacketInfo(
+                arrivalTimeMs,
+                sendTime24bits,
+                packetDetail.packetLength,
+                tccPacket.getSourceSSRC());
         }
     }
 

--- a/src/org/jitsi/impl/neomedia/rtp/TransportCCEngine.java
+++ b/src/org/jitsi/impl/neomedia/rtp/TransportCCEngine.java
@@ -20,6 +20,7 @@ import org.jitsi.impl.neomedia.rtcp.*;
 import org.jitsi.impl.neomedia.rtp.remotebitrateestimator.*;
 import org.jitsi.impl.neomedia.transform.*;
 import org.jitsi.service.neomedia.*;
+import org.jitsi.service.neomedia.rtp.*;
 import org.jitsi.util.*;
 
 import java.io.*;
@@ -39,25 +40,9 @@ import java.util.concurrent.atomic.*;
 public class TransportCCEngine
     extends RTCPPacketListenerAdapter
     implements TransformEngine,
-    RemoteBitrateObserver
+               RemoteBitrateObserver,
+               CallStatsObserver
 {
-    /**
-     *
-     */
-    private static final int kDeltaScaleFactor = 250;
-
-    /**
-     *
-     */
-    private static final long kBaseTimestampScaleFactor
-        = kDeltaScaleFactor * (1 << 8);
-
-    /**
-     *
-     */
-    private static final long kBaseTimestampRangeSizeUs
-        = kBaseTimestampScaleFactor * (1 << 24);
-
     /**
      * The maximum number of received packets and their timestamps to save.
      */
@@ -105,6 +90,12 @@ public class TransportCCEngine
     private final List<MediaStream> mediaStreams = new LinkedList<>();
 
     /**
+     * Some {@link VideoMediaStream} that utilizes this instance. We use it to
+     * get the sender/media SSRC of the outgoing RTCP TCC packets.
+     */
+    private VideoMediaStream anyVideoMediaStream;
+
+    /**
      * Incoming transport-wide sequence numbers mapped to the timestamp of their
      * reception (in milliseconds since the epoch).
      */
@@ -116,12 +107,33 @@ public class TransportCCEngine
     private final Object incomingPacketsSyncRoot = new Object();
 
     /**
+     * Used to synchronize access to {@link #sentPacketDetails}.
+     */
+    private final Object sentPacketsSyncRoot = new Object();
+
+    /**
      * The time (in milliseconds since the epoch) at which the first received
-     * packet in {@link #incomingPackets} was received (or -1 if the map is empty).
+     * packet in {@link #incomingPackets} was received (or -1 if the map is
+     * empty).
      * Kept here for quicker access, because the map is ordered by sequence
      * number.
      */
     private long firstIncomingTs = -1;
+
+    /**
+     * The reference time of the remote clock. This is used to rebase the
+     * arrival times in the TCC packets to a meaningful time base (that of the
+     * sender). This is technically not necessary and it's done for convenience.
+     */
+    private long remoteReferenceTimeMs = -1;
+
+    /**
+     * Local time to map to the reference time of the remote clock. This is used
+     * to rebase the arrival times in the TCC packets to a meaningful time base
+     * (that of the sender). This is technically not necessary and it's done for
+     * convinience.
+     */
+    private long localReferenceTimeMs = -1;
 
     /**
      * Holds a key value pair of the packet sequence number and an object made
@@ -135,16 +147,6 @@ public class TransportCCEngine
      */
     private RemoteBitrateEstimatorAbsSendTime bitrateEstimatorAbsSendTime
         = new RemoteBitrateEstimatorAbsSendTime(this);
-
-    /**
-     * The latest receive timestamp the remote end has sent us (in micros).
-     */
-    private long lastTimestampUs = -1;
-
-    /**
-     * The artificial time offset (in millis) to base remote receipt times.
-     */
-    private long currentOffsetMs = -1;
 
     /**
      * Notifies this instance that a data packet with a specific transport-wide
@@ -184,6 +186,41 @@ public class TransportCCEngine
         }
 
         maybeSendRtcp(marked, now);
+    }
+
+    /**
+     * Gets the source SSRC to use for the outgoing RTCP TCC packets.
+     *
+     * @return the source SSRC to use for the outgoing RTCP TCC packets.
+     */
+    private long getSourceSSRC()
+    {
+        MediaStream stream = anyVideoMediaStream;
+        if (stream == null)
+        {
+            return -1;
+        }
+
+        MediaStreamTrackReceiver receiver
+            = stream.getMediaStreamTrackReceiver();
+        if (receiver == null)
+        {
+            return -1;
+        }
+
+        MediaStreamTrackDesc[] tracks = receiver.getMediaStreamTracks();
+        if (tracks == null || tracks.length == 0)
+        {
+            return -1;
+        }
+
+        RTPEncodingDesc[] encodings = tracks[0].getRTPEncodings();
+        if (encodings == null || encodings.length == 0)
+        {
+            return -1;
+        }
+
+        return encodings[0].getPrimarySSRC();
     }
 
     /**
@@ -234,14 +271,31 @@ public class TransportCCEngine
 
             try
             {
-                // TODO: use the correct SSRCs
-                RTCPTCCPacket rtcpPacket
-                    = new RTCPTCCPacket(
-                    -1, -1,
+                long senderSSRC
+                    = anyVideoMediaStream.getStreamRTPManager().getLocalSSRC();
+                if (senderSSRC == -1)
+                {
+                    logger.warn("No sender SSRC, can't send RTCP.");
+                    return;
+                }
+
+
+                long sourceSSRC = getSourceSSRC();
+                if (sourceSSRC == -1)
+                {
+                    logger.warn("No source SSRC, can't send RTCP.");
+                    return;
+                }
+                RTCPTCCPacket rtcpPacket = new RTCPTCCPacket(
+                    senderSSRC, sourceSSRC,
                     packets,
                     (byte) (outgoingFbPacketCount.getAndIncrement() & 0xff));
-                stream.injectPacket(rtcpPacket.toRawPacket(), false /* rtcp */,
-                    null);
+
+                // Inject the TCC packet *after* this engine. We don't want
+                // RTCP termination -which runs before this engine in the 
+                // egress- to drop the packet we just sent.
+                stream.injectPacket(
+                        rtcpPacket.toRawPacket(), false /* rtcp */, this);
             }
             catch (IllegalArgumentException iae)
             {
@@ -252,13 +306,23 @@ public class TransportCCEngine
                 // We currently don't do this, because it only happens if the
                 // receiver stops sending packets for over 8s. In this case
                 // we will fail to send one feedback message.
-                logger.warn("Not sending transport-cc feedback, delta too big.");
+                logger.warn(
+                        "Not sending transport-cc feedback, delta too big.");
             }
             catch (IOException | TransmissionFailedException e)
             {
                 logger.error("Failed to send transport feedback RTCP: ", e);
             }
         }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void onRttUpdate(long avgRttMs, long maxRttMs)
+    {
+        bitrateEstimatorAbsSendTime.onRttUpdate(avgRttMs, maxRttMs);
     }
 
     /**
@@ -330,41 +394,53 @@ public class TransportCCEngine
             }
         }
 
-        long referenceTime = tccPacket.getReferenceTime();
-        if (lastTimestampUs == -1)
+        RTCPTCCPacket.PacketMap packetMap = tccPacket.getPackets();
+        long previousArrivalTimeMs = -1;
+        for (Map.Entry<Integer, Long> entry : packetMap.entrySet())
         {
-            currentOffsetMs = System.currentTimeMillis();
-        }
-        else
-        {
-            long delta = referenceTime - lastTimestampUs;
-
-            // Detect and compensate for wrap-arounds in base time.
-            if (Math.abs(delta - kBaseTimestampRangeSizeUs) < Math.abs(delta))
+            long arrivalTime250Us = entry.getValue();
+            if (arrivalTime250Us == -1)
             {
-                delta -= kBaseTimestampRangeSizeUs;  // Wrap backwards.
-            }
-            else if (Math.abs(delta + kBaseTimestampRangeSizeUs) < Math.abs(delta))
-            {
-                delta += kBaseTimestampRangeSizeUs;  // Wrap forwards.
+                continue;
             }
 
-            currentOffsetMs += delta / 1000;
-        }
+            if (remoteReferenceTimeMs == -1)
+            {
+                remoteReferenceTimeMs = RTCPTCCPacket.getReferenceTime(
+                        new ByteArrayBufferImpl(
+                            tccPacket.fci, 0, tccPacket.fci.length)) / 4;
 
-        lastTimestampUs = referenceTime;
+                localReferenceTimeMs = System.currentTimeMillis();
+            }
 
-        for (Map.Entry<Integer, Long> entry
-            : tccPacket.getPackets().entrySet())
-        {
-            PacketDetail packetDetail
-                = sentPacketDetails.remove(entry.getKey());
+            PacketDetail packetDetail;
+            synchronized (sentPacketsSyncRoot)
+            {
+                packetDetail = sentPacketDetails.remove(entry.getKey());
+            }
 
             if (packetDetail != null && videoStream != null)
             {
-                long arrivalTimeMs
-                    = currentOffsetMs + entry.getValue() / 1000;
+                long arrivalTimeMs = arrivalTime250Us / 4
+                    - remoteReferenceTimeMs + localReferenceTimeMs;
 
+                if (logger.isDebugEnabled())
+                {
+                    if (previousArrivalTimeMs != -1)
+                    {
+                        long diff_ms = arrivalTimeMs - previousArrivalTimeMs;
+                        logger.debug("seq=" + entry.getKey()
+                                + ", arrival_time_ms=" + arrivalTimeMs
+                                + ", diff_ms=" + diff_ms);
+                    }
+                    else
+                    {
+                        logger.debug("seq=" + entry.getKey()
+                                + ", arrival_time_ms=" + arrivalTimeMs);
+                    }
+                }
+
+                previousArrivalTimeMs = arrivalTimeMs;
                 long sendTime24bits = RemoteBitrateEstimatorAbsSendTime
                     .convertMsTo24Bits(packetDetail.packetSendTimeMs);
 
@@ -415,7 +491,20 @@ public class TransportCCEngine
                     ext.getBuffer(),
                     ext.getOffset() + 1,
                     (short) seq);
-                sentPacketDetails.put(seq, new PacketDetail(pkt.getLength(), System.currentTimeMillis()));
+
+                if (logger.isDebugEnabled())
+                {
+                    logger.debug("rtp_seq=" + pkt.getSequenceNumber()
+                            + ",pt=" + pkt.getPayloadType()
+                            + ",tcc_seq=" + seq);
+                }
+
+                synchronized (sentPacketsSyncRoot)
+                {
+                    sentPacketDetails.put(seq, new PacketDetail(
+                                pkt.getLength(),
+                                System.currentTimeMillis()));
+                }
             }
             return pkt;
         }
@@ -456,6 +545,11 @@ public class TransportCCEngine
             // Hook us up to receive TCCs.
             MediaStreamStats stats = mediaStream.getMediaStreamStats();
             stats.addRTCPPacketListener(this);
+
+            if (mediaStream instanceof VideoMediaStream)
+            {
+                anyVideoMediaStream = (VideoMediaStream) mediaStream;
+            }
         }
     }
 
@@ -476,6 +570,11 @@ public class TransportCCEngine
             // Hook us up to receive TCCs.
             MediaStreamStats stats = mediaStream.getMediaStreamStats();
             stats.removeRTCPPacketListener(this);
+
+            if (mediaStream == anyVideoMediaStream)
+            {
+                anyVideoMediaStream = null;
+            }
         }
     }
 

--- a/src/org/jitsi/impl/neomedia/transform/rtcp/StatisticsEngine.java
+++ b/src/org/jitsi/impl/neomedia/transform/rtcp/StatisticsEngine.java
@@ -1018,10 +1018,6 @@ public class StatisticsEngine
                 }
                 else if (rtcp instanceof RTCPTCCPacket)
                 {
-                    /**
-                     * Intuition: Packet is RTCP, wakeup RTCPPacketListeners which may
-                     * include BWE workers
-                     */
                     streamStats.tccPacketReceived((RTCPTCCPacket)rtcp);
                 }
                 break;

--- a/test/org/jitsi/impl/neomedia/rtcp/RTCPTCCPacketTest.java
+++ b/test/org/jitsi/impl/neomedia/rtcp/RTCPTCCPacketTest.java
@@ -59,15 +59,12 @@ public class RTCPTCCPacketTest
     public void parse()
         throws Exception
     {
-        RTCPTCCPacket tccPacket = new RTCPTCCPacket();
-        RTCPTCCPacket.parseFci(tccPacket, new ByteArrayBufferImpl(fci));
-        RTCPTCCPacket.PacketMap packetMap = tccPacket.getPackets();
+        RTCPTCCPacket.PacketMap packetMap = RTCPTCCPacket.getPacketsFci(new ByteArrayBufferImpl(fci));
 
         assertEquals(5929, packetMap.size());
         assertEquals(4, (int) packetMap.firstKey());
         assertEquals(4 + 5929 - 1, (int) packetMap.lastKey());
-        assertEquals((0x298710L << 8) + 0x2c, tccPacket.getReferenceTime()
-                + packetMap.firstEntry().getValue());
+        assertEquals((0x298710L << 8) + 0x2c, (long) packetMap.firstEntry().getValue());
     }
 
     @Test
@@ -91,9 +88,7 @@ public class RTCPTCCPacketTest
 
         RTCPTCCPacket packet = new RTCPTCCPacket(0, 0, before, (byte) 13);
 
-        RTCPTCCPacket tccPacket = new RTCPTCCPacket();
-        RTCPTCCPacket.parseFci(tccPacket, new ByteArrayBufferImpl(packet.fci));
-        RTCPTCCPacket.PacketMap after = tccPacket.getPackets();
+        RTCPTCCPacket.PacketMap after = RTCPTCCPacket.getPacketsFci(new ByteArrayBufferImpl(packet.fci));
 
         assertEquals(138 - 120 + 1, after.size());
         assertEquals(120, (int) after.firstKey());


### PR DESCRIPTION
- Propagates RTT to the send-side delay-based controller.
- Partially reverts most of the RTCP TCC parsing changes that were
  introduced in e019b4217daa3967efa457c299f76c1f92e012f3.
- Uses correct SSRCs in the outgoing RTCP TCC packets.
- Fixes a synchronization which could lead to undefined behavior of the
  Java Map.