### PR TITLE
Fixes send-side bandwidth estimations and enables log mining.

### DIFF
--- a/src/org/jitsi/impl/neomedia/MediaStreamImpl.java
+++ b/src/org/jitsi/impl/neomedia/MediaStreamImpl.java
@@ -339,6 +339,11 @@ public class MediaStreamImpl
         = new OriginalHeaderBlockTransformEngine();
 
     /**
+     * The {@link DiagnosticContext} that this instance provides.
+     */
+    private final DiagnosticContext diagnosticContext = new DiagnosticContext();
+
+    /**
      * The ID of the frame markings RTP header extension. We use this field as
      * a cache, in order to not access {@link #activeRTPExtensions} every time.
      */
@@ -420,6 +425,16 @@ public class MediaStreamImpl
                     "Created " + getClass().getSimpleName() + " with hashCode "
                         + hashCode());
         }
+
+        diagnosticContext.put("stream", hashCode());
+    }
+
+    /**
+     * Gets the {@link DiagnosticContext} of this instance.
+     */
+    public DiagnosticContext getDiagnosticContext()
+    {
+        return diagnosticContext;
     }
 
     /**

--- a/src/org/jitsi/impl/neomedia/MediaStreamImpl.java
+++ b/src/org/jitsi/impl/neomedia/MediaStreamImpl.java
@@ -1211,7 +1211,7 @@ public class MediaStreamImpl
 
         if (transportCCEngine != null)
         {
-            engineChain.add(transportCCEngine);
+            engineChain.add(transportCCEngine.getEgressEngine());
         }
 
         // Debug
@@ -1228,6 +1228,11 @@ public class MediaStreamImpl
         if (srtpTransformEngine != null)
         {
             engineChain.add(srtpControl.getTransformEngine());
+        }
+
+        if (transportCCEngine != null)
+        {
+            engineChain.add(transportCCEngine.getIngressEngine());
         }
 
         // SSRC audio levels

--- a/src/org/jitsi/impl/neomedia/VideoMediaStreamImpl.java
+++ b/src/org/jitsi/impl/neomedia/VideoMediaStreamImpl.java
@@ -467,7 +467,7 @@ public class VideoMediaStreamImpl
                                     ssrcs,
                                     bitrate);
                     }
-                });
+                }, getDiagnosticContext());
 
     /**
      * The facility which aids this instance in managing a list of
@@ -526,13 +526,6 @@ public class VideoMediaStreamImpl
         super(connector, device, srtpControl);
 
         recurringRunnableExecutor.registerRecurringRunnable(rtcpFeedbackTermination);
-        if (logger.isTraceEnabled())
-        {
-            logger.trace("created_vms," + hashCode()
-                    + "," + System.currentTimeMillis()
-                    + "," + rtcpFeedbackTermination.hashCode()
-                    + "," + remoteBitrateEstimator.hashCode());
-        }
     }
 
     /**

--- a/src/org/jitsi/impl/neomedia/rtcp/RTCPReceiverFeedbackTermination.java
+++ b/src/org/jitsi/impl/neomedia/rtcp/RTCPReceiverFeedbackTermination.java
@@ -289,13 +289,15 @@ public class RTCPReceiverFeedbackTermination
 
                 if (logger.isTraceEnabled())
                 {
-                    logger.trace("created_report_block," + hashCode()
-                            + "," + System.currentTimeMillis()
-                            + "," + reportBlock.getSSRC()
-                            + "," + reportBlock.getNumLost()
-                            + "," + (reportBlock.getFractionLost() / 256D)
-                            + "," + reportBlock.getJitter()
-                            + "," + reportBlock.getXtndSeqNum());
+                    logger.trace(stream.getDiagnosticContext()
+                            .makeTimeSeriesPoint("created_report_block")
+                            .addKey("rtcp_termination", hashCode())
+                            .addField("ssrc", reportBlock.getSSRC())
+                            .addField("num_lost", reportBlock.getNumLost())
+                            .addField("fraction_lost", reportBlock.getFractionLost() / 256D)
+                            .addField("jitter", reportBlock.getJitter())
+                            .addField("xtnd_seqnum", reportBlock.getXtndSeqNum())
+                            .setTimestampMs(System.currentTimeMillis()));
                 }
             }
         }

--- a/src/org/jitsi/impl/neomedia/rtcp/RTCPReceiverFeedbackTermination.java
+++ b/src/org/jitsi/impl/neomedia/rtcp/RTCPReceiverFeedbackTermination.java
@@ -294,10 +294,11 @@ public class RTCPReceiverFeedbackTermination
                             .addKey("rtcp_termination", hashCode())
                             .addField("ssrc", reportBlock.getSSRC())
                             .addField("num_lost", reportBlock.getNumLost())
-                            .addField("fraction_lost", reportBlock.getFractionLost() / 256D)
+                            .addField("fraction_lost",
+                                reportBlock.getFractionLost() / 256D)
                             .addField("jitter", reportBlock.getJitter())
-                            .addField("xtnd_seqnum", reportBlock.getXtndSeqNum())
-                            .setTimestampMs(System.currentTimeMillis()));
+                            .addField("xtnd_seqnum",
+                                reportBlock.getXtndSeqNum()));
                 }
             }
         }

--- a/src/org/jitsi/impl/neomedia/rtcp/RTCPTCCPacket.java
+++ b/src/org/jitsi/impl/neomedia/rtcp/RTCPTCCPacket.java
@@ -510,7 +510,9 @@ public class RTCPTCCPacket
         // Temporary buffer to store the fixed fields (8 bytes) and the list of
         // packet status chunks (see the format above). The buffer may be longer
         // than needed. We pack 7 packets in a chunk, and a chunk is 2 bytes.
-        byte[] buf = new byte[(packetCount / 7 + 1) * 2 + 8];
+        byte[] buf = packetCount % 7 == 0
+            ? new byte[(packetCount / 7) * 2 + 8]
+            : new byte[(packetCount / 7 + 1) * 2 + 8];
         // Temporary buffer to store the list of deltas (see the format above).
         // We allocated for the worst case (2 bytes per packet), which may
         // be longer than needed.
@@ -630,7 +632,7 @@ public class RTCPTCCPacket
         }
 
         off++;
-        if (packetCount % 7 <= 3)
+        if (packetCount % 7 > 0 && packetCount % 7 <= 3)
         {
             // the last chunk was not complete
             buf[off++] = 0;

--- a/src/org/jitsi/impl/neomedia/rtcp/RTCPTCCPacket.java
+++ b/src/org/jitsi/impl/neomedia/rtcp/RTCPTCCPacket.java
@@ -98,7 +98,7 @@ public class RTCPTCCPacket
      * unit facilitates the arrival time computations, as the deltas have 250µs
      * resolution.
      */
-    public static long getReferenceTime(ByteArrayBuffer fciBuffer)
+    public static long getReferenceTime250us(ByteArrayBuffer fciBuffer)
     {
         byte[] buf = fciBuffer.getBuffer();
         int off = fciBuffer.getOffset();
@@ -144,7 +144,7 @@ public class RTCPTCCPacket
         int baseSeq = RTPUtils.readUint16AsInt(buf, off);
         int packetStatusCount = RTPUtils.readUint16AsInt(buf, off + 2);
 
-        long referenceTime = getReferenceTime(fciBuffer);
+        long referenceTime = getReferenceTime250us(fciBuffer);
 
         // The offset at which the packet status chunk list starts.
         int pscOff = off + 8;

--- a/src/org/jitsi/impl/neomedia/rtcp/RTCPTCCPacket.java
+++ b/src/org/jitsi/impl/neomedia/rtcp/RTCPTCCPacket.java
@@ -530,9 +530,8 @@ public class RTCPTCCPacket
         off += RTPUtils.writeShort(buf, off, (short) packetCount);
 
         // Set the 'reference time' field
-        off +=
-            RTPUtils.writeUint24(buf, off,
-                                 (int) ((referenceTime >> 6) & 0xffffff));
+        off += RTPUtils.writeUint24(
+                buf, off, (int) ((referenceTime >> 6) & 0xffffff));
 
         // Set the 'fb pkt count' field. TODO increment
         buf[off++] = fbPacketCount;
@@ -576,7 +575,7 @@ public class RTCPTCCPacket
 
                     // The small delta is an 8-bit unsigned with a resolution of
                     // 250µs. Our deltas are all in milliseconds (hence << 2).
-                    deltas[deltaOff++] = (byte ) ((tsDelta << 2) & 0xff);
+                    deltas[deltaOff++] = (byte) ((tsDelta << 2) & 0xff);
                 }
                 else if (tsDelta < 8191 && tsDelta > -8192)
                 {
@@ -595,7 +594,8 @@ public class RTCPTCCPacket
                     // send feedback with such deltas, we should split it up
                     // into multiple RTCP packets. We can't do that here in the
                     // constructor.
-                    throw new IllegalArgumentException("Delta too big, needs new reference.");
+                    throw new IllegalArgumentException(
+                            "Delta too big, needs new reference.");
                 }
 
                 // If the packet was received, the next delta will be relative
@@ -638,12 +638,10 @@ public class RTCPTCCPacket
             buf[off++] = 0;
         }
 
-
         fci = new byte[off + deltaOff];
         System.arraycopy(buf, 0, fci, 0, off);
         System.arraycopy(deltas, 0, fci, off, deltaOff);
     }
-
 
     /**
      * @return the map of packets represented by this {@link RTCPTCCPacket}.

--- a/src/org/jitsi/impl/neomedia/rtcp/RTCPTCCPacket.java
+++ b/src/org/jitsi/impl/neomedia/rtcp/RTCPTCCPacket.java
@@ -607,27 +607,27 @@ public class RTCPTCCPacket
             // symbol (we've already set 'off' to point to the correct byte).
             //  0 1 2 3 4 5 6 7          8 9 0 1 2 3 4 5
             //  S T <0> <1> <2>          <3> <4> <5> <6>
-            int symbolOffset;
+            int symbolShift;
             switch (seqDelta % 7)
             {
             case 0:
             case 4:
-                symbolOffset = 4;
+                symbolShift = 4;
                 break;
             case 1:
             case 5:
-                symbolOffset = 2;
+                symbolShift = 2;
                 break;
             case 2:
             case 6:
-                symbolOffset = 0;
+                symbolShift = 0;
                 break;
             case 3:
             default:
-                symbolOffset = 6;
+                symbolShift = 6;
             }
 
-            symbol <<= symbolOffset;
+            symbol <<= symbolShift;
             buf[off] |= symbol;
         }
 

--- a/src/org/jitsi/impl/neomedia/rtp/TransportCCEngine.java
+++ b/src/org/jitsi/impl/neomedia/rtp/TransportCCEngine.java
@@ -415,7 +415,7 @@ public class TransportCCEngine
 
             if (remoteReferenceTimeMs == -1)
             {
-                remoteReferenceTimeMs = RTCPTCCPacket.getReferenceTime(
+                remoteReferenceTimeMs = RTCPTCCPacket.getReferenceTime250us(
                         new ByteArrayBufferImpl(
                             tccPacket.fci, 0, tccPacket.fci.length)) / 4;
 

--- a/src/org/jitsi/impl/neomedia/rtp/TransportCCEngine.java
+++ b/src/org/jitsi/impl/neomedia/rtp/TransportCCEngine.java
@@ -212,10 +212,9 @@ public class TransportCCEngine
         if (logger.isTraceEnabled())
         {
             logger.trace(diagnosticContext
-                    .makeTimeSeriesPoint("packet_received")
+                    .makeTimeSeriesPoint("packet_received", now)
                     .addField("seq", seq)
-                    .addField("pt", pt)
-                    .setTimestampMs(now));
+                    .addField("pt", pt));
         }
 
         maybeSendRtcp(marked, now);

--- a/src/org/jitsi/impl/neomedia/rtp/TransportCCEngine.java
+++ b/src/org/jitsi/impl/neomedia/rtp/TransportCCEngine.java
@@ -500,6 +500,7 @@ public class TransportCCEngine
             if (mediaStream instanceof VideoMediaStream)
             {
                 anyVideoMediaStream = (VideoMediaStream) mediaStream;
+                diagnosticContext.put("video_stream", mediaStream.hashCode());
             }
         }
     }

--- a/src/org/jitsi/impl/neomedia/rtp/TransportCCEngine.java
+++ b/src/org/jitsi/impl/neomedia/rtp/TransportCCEngine.java
@@ -166,11 +166,10 @@ public class TransportCCEngine
      */
     public TransportCCEngine(DiagnosticContext diagnosticContext)
     {
-        Objects.requireNonNull(diagnosticContext);
-        this.diagnosticContext = diagnosticContext;
+        this.diagnosticContext
+            = Objects.requireNonNull(diagnosticContext, "diagnosticContext");
         bitrateEstimatorAbsSendTime
-            = new RemoteBitrateEstimatorAbsSendTime(
-                    this, diagnosticContext);
+            = new RemoteBitrateEstimatorAbsSendTime(this, diagnosticContext);
     }
 
     /**
@@ -604,7 +603,7 @@ public class TransportCCEngine
                 if (logger.isDebugEnabled())
                 {
                     logger.debug("rtp_seq=" + pkt.getSequenceNumber()
-                            + ",pt=" + pkt.getPayloadType()
+                            + ",pt=" + RawPacket.getPayloadType(pkt)
                             + ",tcc_seq=" + seq);
                 }
 
@@ -668,7 +667,9 @@ public class TransportCCEngine
                     int seq = RTPUtils.readUint16AsInt(
                             he.getBuffer(), he.getOffset() + 1);
                     packetReceived(
-                            seq, pkt.getPayloadType(), pkt.isPacketMarked());
+                            seq,
+                            RawPacket.getPayloadType(pkt),
+                            pkt.isPacketMarked());
                 }
             }
             return pkt;

--- a/src/org/jitsi/impl/neomedia/rtp/TransportCCEngine.java
+++ b/src/org/jitsi/impl/neomedia/rtp/TransportCCEngine.java
@@ -21,6 +21,7 @@ import org.jitsi.impl.neomedia.rtp.remotebitrateestimator.*;
 import org.jitsi.impl.neomedia.transform.*;
 import org.jitsi.service.neomedia.*;
 import org.jitsi.service.neomedia.rtp.*;
+import org.jetbrains.annotations.*;
 import org.jitsi.util.*;
 
 import java.io.*;
@@ -164,10 +165,9 @@ public class TransportCCEngine
      *
      * @param diagnosicContext the {@link DiagnosticContext} of this instance.
      */
-    public TransportCCEngine(DiagnosticContext diagnosticContext)
+    public TransportCCEngine(@NotNull DiagnosticContext diagnosticContext)
     {
-        this.diagnosticContext
-            = Objects.requireNonNull(diagnosticContext, "diagnosticContext");
+        this.diagnosticContext = diagnosticContext;
         bitrateEstimatorAbsSendTime
             = new RemoteBitrateEstimatorAbsSendTime(this, diagnosticContext);
     }

--- a/src/org/jitsi/impl/neomedia/rtp/remotebitrateestimator/AimdRateControl.java
+++ b/src/org/jitsi/impl/neomedia/rtp/remotebitrateestimator/AimdRateControl.java
@@ -250,10 +250,9 @@ class AimdRateControl
         if (logger.isTraceEnabled())
         {
             logger.trace(diagnosticContext
-                    .makeTimeSeriesPoint("aimd_region")
+                    .makeTimeSeriesPoint("aimd_region", nowMs)
                     .addKey("aimd", hashCode())
-                    .addField("value", region)
-                    .setTimestampMs(nowMs));
+                    .addField("value", region));
         }
     }
 
@@ -294,10 +293,9 @@ class AimdRateControl
         if (logger.isTraceEnabled())
         {
             logger.trace(diagnosticContext
-                    .makeTimeSeriesPoint("aimd_state")
+                    .makeTimeSeriesPoint("aimd_state", nowMs)
                     .addKey("aimd", hashCode())
-                    .addField("value", rateControlState)
-                    .setTimestampMs(nowMs));
+                    .addField("value", rateControlState));
         }
     }
 
@@ -417,10 +415,9 @@ class AimdRateControl
         if (logger.isTraceEnabled())
         {
             logger.trace(diagnosticContext
-                    .makeTimeSeriesPoint("aimd_rtt")
+                    .makeTimeSeriesPoint("aimd_rtt", System.currentTimeMillis())
                     .addKey("aimd", hashCode())
-                    .addField("value", rtt)
-                    .setTimestampMs(System.currentTimeMillis()));
+                    .addField("value", rtt));
         }
 
         this.rtt = rtt;
@@ -473,11 +470,10 @@ class AimdRateControl
         if (logger.isTraceEnabled() && isValidEstimate())
         {
             logger.trace(diagnosticContext
-                .makeTimeSeriesPoint("new_rate_estimate")
+                .makeTimeSeriesPoint("new_rate_estimate", nowMs)
                 .addKey("aimd", hashCode())
                 .addField("estimate", currentBitrateBps)
-                .addField("incoming", currentInput.incomingBitRate)
-                .setTimestampMs(nowMs));
+                .addField("incoming", currentInput.incomingBitRate));
         }
 
         if (nowMs - timeOfLastLog > kLogIntervalMs)

--- a/src/org/jitsi/impl/neomedia/rtp/remotebitrateestimator/AimdRateControl.java
+++ b/src/org/jitsi/impl/neomedia/rtp/remotebitrateestimator/AimdRateControl.java
@@ -91,8 +91,8 @@ class AimdRateControl
     public AimdRateControl(DiagnosticContext diagnosticContext)
     {
         reset();
-        Objects.requireNonNull(diagnosticContext);
-        this.diagnosticContext = diagnosticContext;
+        this.diagnosticContext
+            = Objects.requireNonNull(diagnosticContext, "diagnosticContext");
     }
 
     private long additiveRateIncrease(

--- a/src/org/jitsi/impl/neomedia/rtp/remotebitrateestimator/AimdRateControl.java
+++ b/src/org/jitsi/impl/neomedia/rtp/remotebitrateestimator/AimdRateControl.java
@@ -17,6 +17,7 @@ package org.jitsi.impl.neomedia.rtp.remotebitrateestimator;
 
 import org.jitsi.service.neomedia.rtp.*;
 import org.jitsi.util.*;
+import org.jetbrains.annotations.*;
 
 import java.util.*;
 
@@ -88,11 +89,10 @@ class AimdRateControl
 
     private float varMaxBitrateKbps;
 
-    public AimdRateControl(DiagnosticContext diagnosticContext)
+    public AimdRateControl(@NotNull DiagnosticContext diagnosticContext)
     {
         reset();
-        this.diagnosticContext
-            = Objects.requireNonNull(diagnosticContext, "diagnosticContext");
+        this.diagnosticContext = diagnosticContext;
     }
 
     private long additiveRateIncrease(

--- a/src/org/jitsi/impl/neomedia/rtp/remotebitrateestimator/InterArrival.java
+++ b/src/org/jitsi/impl/neomedia/rtp/remotebitrateestimator/InterArrival.java
@@ -315,12 +315,11 @@ class InterArrival
             long tsDeltaMs = (long) (timestampToMsCoeff * timestampDiff + 0.5);
             boolean inOrder = timestampDiff < 0x80000000L;
 
-            if (logger.isTraceEnabled() && diagnosticContext != null)
+            if (!inOrder && logger.isTraceEnabled())
             {
                 logger.trace(diagnosticContext
                         .makeTimeSeriesPoint("reordered_packet")
                         .addKey("inter_arrival", hashCode())
-                        .addField("in_order", inOrder)
                         .addField("ts_delta_ms", tsDeltaMs));
             }
 

--- a/src/org/jitsi/impl/neomedia/rtp/remotebitrateestimator/InterArrival.java
+++ b/src/org/jitsi/impl/neomedia/rtp/remotebitrateestimator/InterArrival.java
@@ -88,8 +88,8 @@ class InterArrival
         this.timestampToMsCoeff = timestampToMsCoeff;
         burstGrouping = enableBurstGrouping;
         numConsecutiveReorderedPackets = 0;
-        Objects.requireNonNull(diagnosticContext);
-        this.diagnosticContext = diagnosticContext;
+        this.diagnosticContext
+            = Objects.requireNonNull(diagnosticContext, "diagnosticContext");
     }
 
     private boolean belongsToBurst(long arrivalTimeMs, long timestamp)

--- a/src/org/jitsi/impl/neomedia/rtp/remotebitrateestimator/InterArrival.java
+++ b/src/org/jitsi/impl/neomedia/rtp/remotebitrateestimator/InterArrival.java
@@ -17,6 +17,7 @@ package org.jitsi.impl.neomedia.rtp.remotebitrateestimator;
 
 import org.jitsi.impl.neomedia.rtp.TimestampUtils;
 import org.jitsi.util.*;
+import org.jetbrains.annotations.*;
 
 import java.util.*;
 
@@ -82,14 +83,13 @@ class InterArrival
             long timestampGroupLengthTicks,
             double timestampToMsCoeff,
             boolean enableBurstGrouping,
-            DiagnosticContext diagnosticContext)
+            @NotNull DiagnosticContext diagnosticContext)
     {
         kTimestampGroupLengthTicks = timestampGroupLengthTicks;
         this.timestampToMsCoeff = timestampToMsCoeff;
         burstGrouping = enableBurstGrouping;
         numConsecutiveReorderedPackets = 0;
-        this.diagnosticContext
-            = Objects.requireNonNull(diagnosticContext, "diagnosticContext");
+        this.diagnosticContext = diagnosticContext;
     }
 
     private boolean belongsToBurst(long arrivalTimeMs, long timestamp)

--- a/src/org/jitsi/impl/neomedia/rtp/remotebitrateestimator/OveruseDetector.java
+++ b/src/org/jitsi/impl/neomedia/rtp/remotebitrateestimator/OveruseDetector.java
@@ -17,6 +17,8 @@ package org.jitsi.impl.neomedia.rtp.remotebitrateestimator;
 
 import org.jitsi.util.*;
 
+import java.util.*;
+
 /**
  * webrtc/modules/remote_bitrate_estimator/overuse_detector.cc
  * webrtc/modules/remote_bitrate_estimator/overuse_detector.h
@@ -52,12 +54,18 @@ class OveruseDetector
 
     private double timeOverUsing = -1D;
 
-    public OveruseDetector(OverUseDetectorOptions options)
+    private final DiagnosticContext diagnosticContext;
+
+    public OveruseDetector(
+            OverUseDetectorOptions options,
+            DiagnosticContext diagnosticContext)
     {
         if (options == null)
             throw new NullPointerException("options");
 
         threshold = options.initialThreshold;
+        Objects.requireNonNull(diagnosticContext);
+        this.diagnosticContext = diagnosticContext;
 
         if (inExperiment)
             initializeExperiment();
@@ -137,13 +145,15 @@ class OveruseDetector
 
         if (newHypothesis && logger.isTraceEnabled())
         {
-            logger.trace("new_utilization_hypothesis," + hashCode()
-                + "," + nowMs
-                + "," + offset
-                + "," + prev_offset
-                + "," + T
-                + "," + threshold
-                + "," + hypothesis.getValue());
+            logger.trace(diagnosticContext
+                .makeTimeSeriesPoint("utilization_hypothesis")
+                .addKey("detector", hashCode())
+                .addField("offset", offset)
+                .addField("prev_offset", prev_offset)
+                .addField("T", T)
+                .addField("threshold", threshold)
+                .addField("hypothesis", hypothesis.getValue())
+                .setTimestampMs(nowMs));
         }
 
         updateThreshold(T, nowMs);

--- a/src/org/jitsi/impl/neomedia/rtp/remotebitrateestimator/OveruseDetector.java
+++ b/src/org/jitsi/impl/neomedia/rtp/remotebitrateestimator/OveruseDetector.java
@@ -16,6 +16,7 @@
 package org.jitsi.impl.neomedia.rtp.remotebitrateestimator;
 
 import org.jitsi.util.*;
+import org.jetbrains.annotations.*;
 
 import java.util.*;
 
@@ -58,14 +59,13 @@ class OveruseDetector
 
     public OveruseDetector(
             OverUseDetectorOptions options,
-            DiagnosticContext diagnosticContext)
+            @NotNull DiagnosticContext diagnosticContext)
     {
         if (options == null)
             throw new NullPointerException("options");
 
         threshold = options.initialThreshold;
-        this.diagnosticContext
-            = Objects.requireNonNull(diagnosticContext, "diagnosticContext");
+        this.diagnosticContext = diagnosticContext;
 
         if (inExperiment)
             initializeExperiment();

--- a/src/org/jitsi/impl/neomedia/rtp/remotebitrateestimator/OveruseDetector.java
+++ b/src/org/jitsi/impl/neomedia/rtp/remotebitrateestimator/OveruseDetector.java
@@ -146,14 +146,13 @@ class OveruseDetector
         if (newHypothesis && logger.isTraceEnabled())
         {
             logger.trace(diagnosticContext
-                .makeTimeSeriesPoint("utilization_hypothesis")
+                .makeTimeSeriesPoint("utilization_hypothesis", nowMs)
                 .addKey("detector", hashCode())
                 .addField("offset", offset)
                 .addField("prev_offset", prev_offset)
                 .addField("T", T)
                 .addField("threshold", threshold)
-                .addField("hypothesis", hypothesis.getValue())
-                .setTimestampMs(nowMs));
+                .addField("hypothesis", hypothesis.getValue()));
         }
 
         updateThreshold(T, nowMs);

--- a/src/org/jitsi/impl/neomedia/rtp/remotebitrateestimator/OveruseDetector.java
+++ b/src/org/jitsi/impl/neomedia/rtp/remotebitrateestimator/OveruseDetector.java
@@ -64,8 +64,8 @@ class OveruseDetector
             throw new NullPointerException("options");
 
         threshold = options.initialThreshold;
-        Objects.requireNonNull(diagnosticContext);
-        this.diagnosticContext = diagnosticContext;
+        this.diagnosticContext
+            = Objects.requireNonNull(diagnosticContext, "diagnosticContext");
 
         if (inExperiment)
             initializeExperiment();

--- a/src/org/jitsi/impl/neomedia/rtp/remotebitrateestimator/OveruseEstimator.java
+++ b/src/org/jitsi/impl/neomedia/rtp/remotebitrateestimator/OveruseEstimator.java
@@ -62,6 +62,8 @@ class OveruseEstimator
 
     private final double[][] E;
 
+    private DiagnosticContext diagnosticContext;
+
     /**
      * Reduces the effects of allocations and garbage collection of the method
      * {@code update}.
@@ -110,8 +112,12 @@ class OveruseEstimator
 
     private double varNoise;
 
-    public OveruseEstimator(OverUseDetectorOptions options)
+    public OveruseEstimator(
+            OverUseDetectorOptions options,
+            DiagnosticContext diagnosticContext)
     {
+        Objects.requireNonNull(diagnosticContext);
+        this.diagnosticContext = diagnosticContext;
         slope = options.initialSlope;
         offset = options.initialOffset;
         prevOffset = offset;
@@ -252,14 +258,15 @@ class OveruseEstimator
 
         if (logger.isTraceEnabled())
         {
-            logger.trace("new_jitter_estimate" +
-                "," + hashCode() +
-                "," + systemTimeMs +
-                "," + tDelta +
-                "," + tsDelta +
-                "," + tTsDelta +
-                "," + offset +
-                "," + currentHypothesis.getValue());
+            logger.trace(diagnosticContext
+                .makeTimeSeriesPoint("delay_variation_estimation")
+                .addKey("estimator", hashCode())
+                .addField("time_delta", tDelta)
+                .addField("ts_delta", tsDelta)
+                .addField("tts_delta", tTsDelta)
+                .addField("offset", offset)
+                .addField("hypothesis", currentHypothesis.getValue())
+                .setTimestampMs(systemTimeMs));
         }
     }
 

--- a/src/org/jitsi/impl/neomedia/rtp/remotebitrateestimator/OveruseEstimator.java
+++ b/src/org/jitsi/impl/neomedia/rtp/remotebitrateestimator/OveruseEstimator.java
@@ -16,6 +16,7 @@
 package org.jitsi.impl.neomedia.rtp.remotebitrateestimator;
 
 import org.jitsi.util.*;
+import org.jetbrains.annotations.*;
 
 import java.util.*;
 
@@ -114,10 +115,9 @@ class OveruseEstimator
 
     public OveruseEstimator(
             OverUseDetectorOptions options,
-            DiagnosticContext diagnosticContext)
+            @NotNull DiagnosticContext diagnosticContext)
     {
-        this.diagnosticContext
-            = Objects.requireNonNull(diagnosticContext, "diagnosticContext");
+        this.diagnosticContext = diagnosticContext;
         slope = options.initialSlope;
         offset = options.initialOffset;
         prevOffset = offset;

--- a/src/org/jitsi/impl/neomedia/rtp/remotebitrateestimator/OveruseEstimator.java
+++ b/src/org/jitsi/impl/neomedia/rtp/remotebitrateestimator/OveruseEstimator.java
@@ -116,8 +116,8 @@ class OveruseEstimator
             OverUseDetectorOptions options,
             DiagnosticContext diagnosticContext)
     {
-        Objects.requireNonNull(diagnosticContext);
-        this.diagnosticContext = diagnosticContext;
+        this.diagnosticContext
+            = Objects.requireNonNull(diagnosticContext, "diagnosticContext");
         slope = options.initialSlope;
         offset = options.initialOffset;
         prevOffset = offset;

--- a/src/org/jitsi/impl/neomedia/rtp/remotebitrateestimator/OveruseEstimator.java
+++ b/src/org/jitsi/impl/neomedia/rtp/remotebitrateestimator/OveruseEstimator.java
@@ -259,14 +259,13 @@ class OveruseEstimator
         if (logger.isTraceEnabled())
         {
             logger.trace(diagnosticContext
-                .makeTimeSeriesPoint("delay_variation_estimation")
+                .makeTimeSeriesPoint("delay_variation_estimation", systemTimeMs)
                 .addKey("estimator", hashCode())
                 .addField("time_delta", tDelta)
                 .addField("ts_delta", tsDelta)
                 .addField("tts_delta", tTsDelta)
                 .addField("offset", offset)
-                .addField("hypothesis", currentHypothesis.getValue())
-                .setTimestampMs(systemTimeMs));
+                .addField("hypothesis", currentHypothesis.getValue()));
         }
     }
 

--- a/src/org/jitsi/impl/neomedia/rtp/remotebitrateestimator/RemoteBitrateEstimatorAbsSendTime.java
+++ b/src/org/jitsi/impl/neomedia/rtp/remotebitrateestimator/RemoteBitrateEstimatorAbsSendTime.java
@@ -462,14 +462,13 @@ public class RemoteBitrateEstimatorAbsSendTime
         if (logger.isTraceEnabled())
         {
             logger.trace(diagnosticContext
-                .makeTimeSeriesPoint("incoming_packet")
+                .makeTimeSeriesPoint("incoming_packet", nowMs)
                 .addKey("rbe", hashCode())
                 .addField("arrival_time_ms", arrivalTimeMs)
                 .addField("send_time_24bits", sendTime24bits)
                 .addField("send_time_ms", sendTimeMs)
                 .addField("payload_size", payloadSize)
-                .addField("ssrc", ssrc)
-                .setTimestampMs(nowMs));
+                .addField("ssrc", ssrc));
         }
 
         // should be broken out from  here.

--- a/src/org/jitsi/impl/neomedia/rtp/remotebitrateestimator/RemoteBitrateEstimatorAbsSendTime.java
+++ b/src/org/jitsi/impl/neomedia/rtp/remotebitrateestimator/RemoteBitrateEstimatorAbsSendTime.java
@@ -454,6 +454,11 @@ public class RemoteBitrateEstimatorAbsSendTime
         // Convert the expanded AST (32 bits, 6.26 fixed point) to millis.
         long sendTimeMs = (long) (timestamp * kTimestampToMs);
 
+        // XXX The arrival time should be the earliest we've seen this packet,
+        // not now. In our code however, we don't have access to the arrival
+        // time.
+        long nowMs = System.currentTimeMillis();
+
         if (logger.isTraceEnabled())
         {
             logger.trace(diagnosticContext
@@ -463,13 +468,9 @@ public class RemoteBitrateEstimatorAbsSendTime
                 .addField("send_time_24bits", sendTime24bits)
                 .addField("send_time_ms", sendTimeMs)
                 .addField("payload_size", payloadSize)
-                .addField("ssrc", ssrc));
+                .addField("ssrc", ssrc)
+                .setTimestampMs(nowMs));
         }
-
-        // XXX The arrival time should be the earliest we've seen this packet,
-        // not now. In our code however, we don't have access to the arrival
-        // time.
-        long nowMs = System.currentTimeMillis();
 
         // should be broken out from  here.
         // Check if incoming bitrate estimate is valid, and if it

--- a/src/org/jitsi/impl/neomedia/rtp/remotebitrateestimator/RemoteBitrateEstimatorAbsSendTime.java
+++ b/src/org/jitsi/impl/neomedia/rtp/remotebitrateestimator/RemoteBitrateEstimatorAbsSendTime.java
@@ -20,6 +20,7 @@ import org.ice4j.util.*;
 import org.jitsi.service.neomedia.rtp.*;
 import org.jitsi.util.Logger;
 import org.jitsi.util.*;
+import org.jetbrains.annotations.*;
 
 import java.util.*;
 
@@ -212,11 +213,10 @@ public class RemoteBitrateEstimatorAbsSendTime
      */
     public RemoteBitrateEstimatorAbsSendTime(
             RemoteBitrateObserver observer,
-            DiagnosticContext diagnosticContext)
+            @NotNull DiagnosticContext diagnosticContext)
     {
         this.observer = observer;
-        this.diagnosticContext
-            = Objects.requireNonNull(diagnosticContext, "diagnosticContext");
+        this.diagnosticContext = diagnosticContext;
         this.remoteRate = new AimdRateControl(diagnosticContext);
         this.incomingBitrate = new RateStatistics(kBitrateWindowMs, kBitrateScale);
         this.incomingBitrateInitialized = false;

--- a/src/org/jitsi/impl/neomedia/rtp/remotebitrateestimator/RemoteBitrateEstimatorAbsSendTime.java
+++ b/src/org/jitsi/impl/neomedia/rtp/remotebitrateestimator/RemoteBitrateEstimatorAbsSendTime.java
@@ -215,8 +215,8 @@ public class RemoteBitrateEstimatorAbsSendTime
             DiagnosticContext diagnosticContext)
     {
         this.observer = observer;
-        Objects.requireNonNull(diagnosticContext);
-        this.diagnosticContext = diagnosticContext;
+        this.diagnosticContext
+            = Objects.requireNonNull(diagnosticContext, "diagnosticContext");
         this.remoteRate = new AimdRateControl(diagnosticContext);
         this.incomingBitrate = new RateStatistics(kBitrateWindowMs, kBitrateScale);
         this.incomingBitrateInitialized = false;

--- a/src/org/jitsi/impl/neomedia/rtp/remotebitrateestimator/RemoteBitrateEstimatorSingleStream.java
+++ b/src/org/jitsi/impl/neomedia/rtp/remotebitrateestimator/RemoteBitrateEstimatorSingleStream.java
@@ -21,6 +21,7 @@ import net.sf.fmj.media.rtp.util.*;
 
 import org.ice4j.util.*;
 import org.jitsi.service.neomedia.rtp.*;
+import org.jitsi.util.*;
 
 /**
  * webrtc/modules/remote_bitrate_estimator/remote_bitrate_estimator_single_stream.cc
@@ -64,7 +65,7 @@ public class RemoteBitrateEstimatorSingleStream
 
     private long processIntervalMs = kProcessIntervalMs;
 
-    private final AimdRateControl remoteRate = new AimdRateControl();
+    private final AimdRateControl remoteRate;
 
     /**
      * The set of synchronization source identifiers (SSRCs) currently being
@@ -75,9 +76,16 @@ public class RemoteBitrateEstimatorSingleStream
      */
     private Collection<Long> ssrcs;
 
-    public RemoteBitrateEstimatorSingleStream(RemoteBitrateObserver observer)
+    private final DiagnosticContext diagnosticContext;
+
+    public RemoteBitrateEstimatorSingleStream(
+            RemoteBitrateObserver observer,
+            DiagnosticContext diagnosticContext)
     {
         this.observer = observer;
+        Objects.requireNonNull(diagnosticContext);
+        this.diagnosticContext = diagnosticContext;
+        this.remoteRate = new AimdRateControl(diagnosticContext);
     }
 
     private long getExtensionTransmissionTimeOffset(RTPPacket header)
@@ -330,7 +338,7 @@ public class RemoteBitrateEstimatorSingleStream
         } // synchronized (critSect)
     }
 
-    private static class Detector
+    private class Detector
     {
         public OveruseDetector detector;
 
@@ -350,9 +358,11 @@ public class RemoteBitrateEstimatorSingleStream
                 = new InterArrival(
                         90 * kTimestampGroupLengthMs,
                         kTimestampToMs,
-                        enableBurstGrouping);
-            this.estimator = new OveruseEstimator(options);
-            this.detector = new OveruseDetector(options);
+                        enableBurstGrouping,
+                        diagnosticContext);
+
+            this.estimator = new OveruseEstimator(options, diagnosticContext);
+            this.detector = new OveruseDetector(options, diagnosticContext);
         }
     }
 }

--- a/src/org/jitsi/impl/neomedia/rtp/remotebitrateestimator/RemoteBitrateEstimatorSingleStream.java
+++ b/src/org/jitsi/impl/neomedia/rtp/remotebitrateestimator/RemoteBitrateEstimatorSingleStream.java
@@ -83,8 +83,8 @@ public class RemoteBitrateEstimatorSingleStream
             DiagnosticContext diagnosticContext)
     {
         this.observer = observer;
-        Objects.requireNonNull(diagnosticContext);
-        this.diagnosticContext = diagnosticContext;
+        this.diagnosticContext
+            = Objects.requireNonNull(diagnosticContext, "diagnosticContext");
         this.remoteRate = new AimdRateControl(diagnosticContext);
     }
 

--- a/src/org/jitsi/impl/neomedia/rtp/remotebitrateestimator/RemoteBitrateEstimatorSingleStream.java
+++ b/src/org/jitsi/impl/neomedia/rtp/remotebitrateestimator/RemoteBitrateEstimatorSingleStream.java
@@ -22,6 +22,7 @@ import net.sf.fmj.media.rtp.util.*;
 import org.ice4j.util.*;
 import org.jitsi.service.neomedia.rtp.*;
 import org.jitsi.util.*;
+import org.jetbrains.annotations.*;
 
 /**
  * webrtc/modules/remote_bitrate_estimator/remote_bitrate_estimator_single_stream.cc
@@ -80,11 +81,10 @@ public class RemoteBitrateEstimatorSingleStream
 
     public RemoteBitrateEstimatorSingleStream(
             RemoteBitrateObserver observer,
-            DiagnosticContext diagnosticContext)
+            @NotNull DiagnosticContext diagnosticContext)
     {
         this.observer = observer;
-        this.diagnosticContext
-            = Objects.requireNonNull(diagnosticContext, "diagnosticContext");
+        this.diagnosticContext = diagnosticContext;
         this.remoteRate = new AimdRateControl(diagnosticContext);
     }
 

--- a/src/org/jitsi/impl/neomedia/rtp/remotebitrateestimator/RemoteBitrateEstimatorWrapper.java
+++ b/src/org/jitsi/impl/neomedia/rtp/remotebitrateestimator/RemoteBitrateEstimatorWrapper.java
@@ -121,7 +121,7 @@ public class RemoteBitrateEstimatorWrapper
     private RemoteBitrateEstimator rbe;
 
     /**
-     * The {@link DiangosticContext} for this instance.
+     * The {@link DiagnosticContext} for this instance.
      */
     private final DiagnosticContext diagnosticContext;
 
@@ -137,9 +137,8 @@ public class RemoteBitrateEstimatorWrapper
             DiagnosticContext diagnosticContext)
     {
         this.observer = observer;
-
-        Objects.requireNonNull(diagnosticContext);
-        this.diagnosticContext = diagnosticContext;
+        this.diagnosticContext
+            = Objects.requireNonNull(diagnosticContext, "diagnosticContext");
         // Initialize to the default RTP timestamp based RBE.
         this.rbe = new RemoteBitrateEstimatorSingleStream(
                 observer, diagnosticContext);
@@ -267,8 +266,6 @@ public class RemoteBitrateEstimatorWrapper
             incomingPacketInfo(System.currentTimeMillis(), sendTime24bits,
                 pkt.getPayloadLength(), pkt.getSSRCAsLong());
         }
-
-        // FIXME what if we don't have abs-send-time header extension.
 
         return pkt;
     }

--- a/src/org/jitsi/impl/neomedia/rtp/remotebitrateestimator/RemoteBitrateEstimatorWrapper.java
+++ b/src/org/jitsi/impl/neomedia/rtp/remotebitrateestimator/RemoteBitrateEstimatorWrapper.java
@@ -20,6 +20,7 @@ import org.jitsi.service.configuration.*;
 import org.jitsi.service.libjitsi.*;
 import org.jitsi.service.neomedia.*;
 import org.jitsi.service.neomedia.rtp.*;
+import org.jetbrains.annotations.*;
 
 import java.util.*;
 import org.jitsi.util.*;
@@ -134,11 +135,10 @@ public class RemoteBitrateEstimatorWrapper
      */
     public RemoteBitrateEstimatorWrapper(
             RemoteBitrateObserver observer,
-            DiagnosticContext diagnosticContext)
+            @NotNull DiagnosticContext diagnosticContext)
     {
         this.observer = observer;
-        this.diagnosticContext
-            = Objects.requireNonNull(diagnosticContext, "diagnosticContext");
+        this.diagnosticContext = diagnosticContext;
         // Initialize to the default RTP timestamp based RBE.
         this.rbe = new RemoteBitrateEstimatorSingleStream(
                 observer, diagnosticContext);

--- a/src/org/jitsi/impl/neomedia/rtp/sendsidebandwidthestimation/BandwidthEstimatorImpl.java
+++ b/src/org/jitsi/impl/neomedia/rtp/sendsidebandwidthestimation/BandwidthEstimatorImpl.java
@@ -18,6 +18,7 @@ package org.jitsi.impl.neomedia.rtp.sendsidebandwidthestimation;
 import net.sf.fmj.media.rtp.*;
 import org.jitsi.service.configuration.*;
 import org.jitsi.service.libjitsi.*;
+import org.jitsi.impl.neomedia.*;
 import org.jitsi.service.neomedia.*;
 import org.jitsi.service.neomedia.rtp.*;
 
@@ -85,7 +86,7 @@ public class BandwidthEstimatorImpl
      * {@link MediaStream}.
      * @param stream the {@link MediaStream}.
      */
-    public BandwidthEstimatorImpl(MediaStream stream)
+    public BandwidthEstimatorImpl(MediaStreamImpl stream)
     {
         sendSideBandwidthEstimation
             = new SendSideBandwidthEstimation(stream, START_BITRATE_BPS);

--- a/src/org/jitsi/impl/neomedia/rtp/sendsidebandwidthestimation/SendSideBandwidthEstimation.java
+++ b/src/org/jitsi/impl/neomedia/rtp/sendsidebandwidthestimation/SendSideBandwidthEstimation.java
@@ -231,7 +231,8 @@ class SendSideBandwidthEstimation
                             .makeTimeSeriesPoint("ssbwe_update")
                             .addField("action", "increase")
                             .addField("last_fraction_loss", last_fraction_loss_)
-                            .addField("bitrate", bitrate));
+                            .addField("bitrate", bitrate)
+                            .setTimestampMs(now));
                 }
 
             }
@@ -245,7 +246,8 @@ class SendSideBandwidthEstimation
                             .makeTimeSeriesPoint("ssbwe_update")
                             .addField("action", "keep")
                             .addField("last_fraction_loss", last_fraction_loss_)
-                            .addField("bitrate", bitrate));
+                            .addField("bitrate", bitrate)
+                            .setTimestampMs(now));
                 }
             }
             else
@@ -271,7 +273,8 @@ class SendSideBandwidthEstimation
                                 .makeTimeSeriesPoint("ssbwe_update")
                                 .addField("action", "decrease")
                                 .addField("last_fraction_loss", last_fraction_loss_)
-                                .addField("bitrate", bitrate));
+                                .addField("bitrate", bitrate)
+                                .setTimestampMs(now));
                     }
                 }
             }
@@ -354,7 +357,8 @@ class SendSideBandwidthEstimation
         {
             logger.trace(diagnosticContext
                     .makeTimeSeriesPoint("ssbwe_update_receiver_estimate")
-                    .addField("estimate", bandwidth));
+                    .addField("estimate", bandwidth)
+                    .setTimestampMs(System.currentTimeMillis()));
         }
         setBitrate(capBitrateToThresholds(bitrate_));
     }

--- a/src/org/jitsi/impl/neomedia/rtp/sendsidebandwidthestimation/SendSideBandwidthEstimation.java
+++ b/src/org/jitsi/impl/neomedia/rtp/sendsidebandwidthestimation/SendSideBandwidthEstimation.java
@@ -228,11 +228,10 @@ class SendSideBandwidthEstimation
                 if (logger.isTraceEnabled())
                 {
                     logger.trace(diagnosticContext
-                            .makeTimeSeriesPoint("ssbwe_update")
+                            .makeTimeSeriesPoint("ssbwe_update", now)
                             .addField("action", "increase")
                             .addField("last_fraction_loss", last_fraction_loss_)
-                            .addField("bitrate", bitrate)
-                            .setTimestampMs(now));
+                            .addField("bitrate", bitrate));
                 }
 
             }
@@ -243,11 +242,10 @@ class SendSideBandwidthEstimation
                 if (logger.isTraceEnabled())
                 {
                     logger.trace(diagnosticContext
-                            .makeTimeSeriesPoint("ssbwe_update")
+                            .makeTimeSeriesPoint("ssbwe_update", now)
                             .addField("action", "keep")
                             .addField("last_fraction_loss", last_fraction_loss_)
-                            .addField("bitrate", bitrate)
-                            .setTimestampMs(now));
+                            .addField("bitrate", bitrate));
                 }
             }
             else
@@ -270,11 +268,10 @@ class SendSideBandwidthEstimation
                     if (logger.isTraceEnabled())
                     {
                         logger.trace(diagnosticContext
-                                .makeTimeSeriesPoint("ssbwe_update")
+                                .makeTimeSeriesPoint("ssbwe_update", now)
                                 .addField("action", "decrease")
                                 .addField("last_fraction_loss", last_fraction_loss_)
-                                .addField("bitrate", bitrate)
-                                .setTimestampMs(now));
+                                .addField("bitrate", bitrate));
                     }
                 }
             }
@@ -356,9 +353,9 @@ class SendSideBandwidthEstimation
         if (logger.isTraceEnabled())
         {
             logger.trace(diagnosticContext
-                    .makeTimeSeriesPoint("ssbwe_update_receiver_estimate")
-                    .addField("estimate", bandwidth)
-                    .setTimestampMs(System.currentTimeMillis()));
+                    .makeTimeSeriesPoint("ssbwe_update_receiver_estimate",
+                        System.currentTimeMillis())
+                    .addField("estimate", bandwidth));
         }
         setBitrate(capBitrateToThresholds(bitrate_));
     }

--- a/src/org/jitsi/impl/neomedia/rtp/sendsidebandwidthestimation/SendSideBandwidthEstimation.java
+++ b/src/org/jitsi/impl/neomedia/rtp/sendsidebandwidthestimation/SendSideBandwidthEstimation.java
@@ -17,6 +17,7 @@ package org.jitsi.impl.neomedia.rtp.sendsidebandwidthestimation;
 
 import org.jitsi.impl.neomedia.rtcp.*;
 import org.jitsi.impl.neomedia.rtp.*;
+import org.jitsi.impl.neomedia.*;
 import org.jitsi.service.neomedia.*;
 import org.jitsi.service.neomedia.rtp.*;
 import org.jitsi.util.*;
@@ -134,6 +135,11 @@ class SendSideBandwidthEstimation
      */
     private Deque<Pair<Long>> min_bitrate_history_ = new LinkedList<>();
 
+    /**
+     * The {@link DiagnosticContext} of this instance.
+     */
+    private final DiagnosticContext diagnosticContext;
+
     private final List<BandwidthEstimator.Listener> listeners
         = new LinkedList<>();
 
@@ -142,9 +148,10 @@ class SendSideBandwidthEstimation
      */
     private final MediaStream mediaStream;
 
-    SendSideBandwidthEstimation(MediaStream stream, long startBitrate)
+    SendSideBandwidthEstimation(MediaStreamImpl stream, long startBitrate)
     {
         mediaStream = stream;
+        diagnosticContext = stream.getDiagnosticContext();
         setBitrate(startBitrate);
     }
 
@@ -218,11 +225,13 @@ class SendSideBandwidthEstimation
                 // rates).
                 bitrate += 1000;
 
-                if (logger.isDebugEnabled())
+                if (logger.isTraceEnabled())
                 {
-                    logger.debug("bwe,stream=" + mediaStream.hashCode() +
-                        " action=increase,last_fraction_loss=" + last_fraction_loss_ +
-                        ",bitrate=" + bitrate);
+                    logger.trace(diagnosticContext
+                            .makeTimeSeriesPoint("ssbwe_update")
+                            .addField("action", "increase")
+                            .addField("last_fraction_loss", last_fraction_loss_)
+                            .addField("bitrate", bitrate));
                 }
 
             }
@@ -230,11 +239,13 @@ class SendSideBandwidthEstimation
             {
                 // Loss between 2% - 10%: Do nothing.
 
-                if (logger.isDebugEnabled())
+                if (logger.isTraceEnabled())
                 {
-                    logger.debug("bwe,stream=" + mediaStream.hashCode() +
-                        " action=keep,last_fraction_loss=" + last_fraction_loss_ +
-                        ",bitrate=" + bitrate);
+                    logger.trace(diagnosticContext
+                            .makeTimeSeriesPoint("ssbwe_update")
+                            .addField("action", "keep")
+                            .addField("last_fraction_loss", last_fraction_loss_)
+                            .addField("bitrate", bitrate));
                 }
             }
             else
@@ -254,11 +265,13 @@ class SendSideBandwidthEstimation
                         (bitrate * (512 - last_fraction_loss_)) / 512.0);
                     has_decreased_since_last_fraction_loss_ = true;
 
-                    if (logger.isDebugEnabled())
+                    if (logger.isTraceEnabled())
                     {
-                        logger.debug("bwe,stream=" + mediaStream.hashCode() +
-                            " action=decrease,last_fraction_loss=" + last_fraction_loss_ +
-                            ",bitrate=" + bitrate);
+                        logger.trace(diagnosticContext
+                                .makeTimeSeriesPoint("ssbwe_update")
+                                .addField("action", "decrease")
+                                .addField("last_fraction_loss", last_fraction_loss_)
+                                .addField("bitrate", bitrate));
                     }
                 }
             }
@@ -337,10 +350,11 @@ class SendSideBandwidthEstimation
     public synchronized void updateReceiverEstimate(long bandwidth)
     {
         bwe_incoming_ = bandwidth;
-        if (logger.isDebugEnabled())
+        if (logger.isTraceEnabled())
         {
-            logger.debug("bwe,stream=" + mediaStream.hashCode() +
-                " receiver_estimate=" + bandwidth);
+            logger.trace(diagnosticContext
+                    .makeTimeSeriesPoint("ssbwe_update_receiver_estimate")
+                    .addField("estimate", bandwidth));
         }
         setBitrate(capBitrateToThresholds(bitrate_));
     }

--- a/src/org/jitsi/service/neomedia/RawPacket.java
+++ b/src/org/jitsi/service/neomedia/RawPacket.java
@@ -1171,7 +1171,7 @@ public class RawPacket
     /**
      * Get RTP payload type from a RTP packet
      *
-     * @return RTP payload type of source RTP packet
+     * @return RTP payload type of source RTP packet, or -1 in case of an error.
      */
     public static int getPayloadType(byte[] buf, int off, int len)
     {
@@ -1181,6 +1181,22 @@ public class RawPacket
         }
 
         return (buf[off + 1] & 0x7F);
+    }
+
+    /**
+     * Get RTP payload type from a RTP packet
+     *
+     * @return RTP payload type of source RTP packet, or -1 in case of an error.
+     */
+    public static int getPayloadType(RawPacket pkt)
+    {
+        if (pkt == null)
+        {
+            return -1;
+        }
+
+        return getPayloadType(
+                pkt.getBuffer(), pkt.getOffset(), pkt.getLength());
     }
 
     /**

--- a/src/org/jitsi/util/DiagnosticContext.java
+++ b/src/org/jitsi/util/DiagnosticContext.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright @ 2017 Atlassian Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.util;
+
+import java.util.*;
+import java.util.concurrent.*;
+
+/**
+ * A {@link DiagnosticContext} implementation backed by a
+ * {@link ConcurrentHashMap}.
+ *
+ * @author George Politis
+ */
+public class DiagnosticContext
+{
+    /**
+     * The store for this diagnostic context.
+     */
+    private final Map<String, Object> ctxKeys = new ConcurrentHashMap<>();
+
+    /**
+     * Puts a variable in the diagnostic context store.
+     */
+    public void put(String key, Object val)
+    {
+        if (key != null && val != null)
+        {
+            ctxKeys.put(key, val);
+        }
+    }
+
+    /**
+     * Makes a new time series point.
+     */
+    public TimeSeriesPoint makeTimeSeriesPoint(String timeSeriesName)
+    {
+        return new TimeSeriesPoint(timeSeriesName);
+    }
+
+    /**
+     * Represents a time series point. The <tt>toString</tt> method outputs
+     * the time series point in influx DB line protocol format.
+     */
+    public class TimeSeriesPoint
+    {
+        private final String timeSeriesName;
+
+        private final Map<String, Object> keys;
+
+        private final Map<String, Object> fields;
+
+        private long tsMs = -1;
+
+        /**
+         * Ctor.
+         */
+        public TimeSeriesPoint(String timeSeriesName)
+        {
+            this.timeSeriesName = timeSeriesName;
+            this.keys = new HashMap<>(ctxKeys /* snapshot of the ctx keys */);
+            this.fields = new HashMap<>();
+        }
+
+        /**
+         * Adds a key to the time series point.
+         */
+        public TimeSeriesPoint addKey(String key, Object value)
+        {
+            if (key != null && value != null)
+            {
+                keys.put(key, value);
+            }
+            return this;
+        }
+
+        /**
+         * Adds a field to the time series point.
+         */
+        public TimeSeriesPoint addField(String key, Object value)
+        {
+            if (key != null && value != null)
+            {
+                fields.put(key, value);
+            }
+            return this;
+        }
+
+        /**
+         * Sets the timestamp of the time series point.
+         */
+        public TimeSeriesPoint setTimestampMs(long tsMs)
+        {
+            this.tsMs = tsMs;
+            return this;
+        }
+
+        /**
+         * Prints the time series point in influx DB line protocol format.
+         */
+        public String toString()
+        {
+            StringBuilder sb = new StringBuilder(timeSeriesName);
+            for (Map.Entry<String, Object> keyEntry : keys.entrySet())
+            {
+                sb.append(",")
+                    .append(keyEntry.getKey())
+                    .append("=")
+                    .append(keyEntry.getValue());
+            }
+
+            if (!fields.isEmpty())
+            {
+                boolean isFirstField = true;
+                for (Map.Entry<String, Object> fieldEntry : fields.entrySet())
+                {
+                    sb.append(isFirstField ? " " : ",")
+                        .append(fieldEntry.getKey())
+                        .append("=")
+                        .append(fieldEntry.getValue());
+
+                    isFirstField = false;
+                }
+            }
+
+            if (tsMs != -1)
+            {
+                sb.append(" ").append(tsMs);
+            }
+
+            return sb.toString();
+        }
+    }
+}

--- a/src/org/jitsi/util/DiagnosticContext.java
+++ b/src/org/jitsi/util/DiagnosticContext.java
@@ -43,11 +43,27 @@ public class DiagnosticContext
     }
 
     /**
-     * Makes a new time series point.
+     * Makes a new time series point without a timestamp. This is recommended
+     * for time series where the exact timestamp value isn't important and can
+     * be deduced via other means (i.e. Java logging timestamps).
+     *
+     * @param timeSeriesName the name of the time series
      */
     public TimeSeriesPoint makeTimeSeriesPoint(String timeSeriesName)
     {
-        return new TimeSeriesPoint(timeSeriesName);
+        return new TimeSeriesPoint(timeSeriesName, -1);
+    }
+
+    /**
+     * Makes a new time series point with a timestamp. This is recommended for
+     * time series where it's important to have the exact timestamp value.
+     *
+     * @param timeSeriesName the name of the time series
+     * @param tsMs the timestamp of the time series point (in millis)
+     */
+    public TimeSeriesPoint makeTimeSeriesPoint(String timeSeriesName, long tsMs)
+    {
+        return new TimeSeriesPoint(timeSeriesName, tsMs);
     }
 
     /**
@@ -62,16 +78,20 @@ public class DiagnosticContext
 
         private final Map<String, Object> fields;
 
-        private long tsMs = -1;
+        private final long tsMs;
 
         /**
          * Ctor.
+         *
+         * @param timeSeriesName the name of the time series
+         * @param tsMs the timestamp of the time series point (in millis)
          */
-        public TimeSeriesPoint(String timeSeriesName)
+        public TimeSeriesPoint(String timeSeriesName, long tsMs)
         {
             this.timeSeriesName = timeSeriesName;
             this.keys = new HashMap<>(ctxKeys /* snapshot of the ctx keys */);
             this.fields = new HashMap<>();
+            this.tsMs = tsMs;
         }
 
         /**
@@ -95,15 +115,6 @@ public class DiagnosticContext
             {
                 fields.put(key, value);
             }
-            return this;
-        }
-
-        /**
-         * Sets the timestamp of the time series point.
-         */
-        public TimeSeriesPoint setTimestampMs(long tsMs)
-        {
-            this.tsMs = tsMs;
             return this;
         }
 

--- a/test/org/jitsi/impl/neomedia/rtcp/RTCPTCCPacketTest.java
+++ b/test/org/jitsi/impl/neomedia/rtcp/RTCPTCCPacketTest.java
@@ -123,7 +123,7 @@ public class RTCPTCCPacketTest
         int referenceTime64ms = (int) ((nowMs >> 6) & 0xffffff);
         long referenceTime250us = referenceTime64ms << 8;
         assertEquals(referenceTime250us,
-                RTCPTCCPacket.getReferenceTime(afterBaf));
+                RTCPTCCPacket.getReferenceTime250us(afterBaf));
 
         long nextReferenceTime250us = referenceTime250us + (60 << 2);
         assertEquals(nextReferenceTime250us, (long) after.get(1268));

--- a/test/org/jitsi/impl/neomedia/rtcp/RTCPTCCPacketTest.java
+++ b/test/org/jitsi/impl/neomedia/rtcp/RTCPTCCPacketTest.java
@@ -95,4 +95,51 @@ public class RTCPTCCPacketTest
         assertEquals(138, (int) after.lastKey());
         assertEquals(13, packet.getFbPacketCount());
     }
+
+    @Test
+    public void createAndParse7()
+        throws Exception
+    {
+        long nowMs = 1515520570364L;
+        RTCPTCCPacket.PacketMap before = new RTCPTCCPacket.PacketMap();
+        before.put(1268, nowMs);
+        before.put(1269, nowMs + 7);
+        before.put(1270, nowMs + 7);
+        before.put(1271, nowMs + 12);
+        before.put(1272, nowMs + 18);
+        before.put(1273, nowMs + 18);
+        before.put(1274, nowMs + 35);
+
+        RTCPTCCPacket packet = new RTCPTCCPacket(0, 0, before, (byte) 13);
+
+        ByteArrayBufferImpl afterBaf = new ByteArrayBufferImpl(packet.fci);
+        RTCPTCCPacket.PacketMap after = RTCPTCCPacket.getPacketsFci(afterBaf);
+
+        assertEquals(1274 - 1268 + 1, after.size());
+        assertEquals(1268, (int) after.firstKey());
+        assertEquals(1274, (int) after.lastKey());
+        assertEquals(13, packet.getFbPacketCount());
+
+        int referenceTime64ms = (int) ((nowMs >> 6) & 0xffffff);
+        long referenceTime250us = referenceTime64ms << 8;
+        assertEquals(referenceTime250us,
+                RTCPTCCPacket.getReferenceTime(afterBaf));
+
+        long nextReferenceTime250us = referenceTime250us + (60 << 2);
+        assertEquals(nextReferenceTime250us, (long) after.get(1268));
+
+        nextReferenceTime250us = nextReferenceTime250us + (7 << 2);
+        assertEquals(nextReferenceTime250us, (long) after.get(1269));
+        assertEquals(nextReferenceTime250us, (long) after.get(1270));
+
+        nextReferenceTime250us = nextReferenceTime250us + (5 << 2);
+        assertEquals(nextReferenceTime250us, (long) after.get(1271));
+
+        nextReferenceTime250us = nextReferenceTime250us + (6 << 2);
+        assertEquals(nextReferenceTime250us, (long) after.get(1272));
+        assertEquals(nextReferenceTime250us, (long) after.get(1273));
+
+        nextReferenceTime250us = nextReferenceTime250us + (17 << 2);
+        assertEquals(nextReferenceTime250us, (long) after.get(1274));
+    }
 }

--- a/test/org/jitsi/impl/neomedia/rtcp/RTCPTCCPacketTest.java
+++ b/test/org/jitsi/impl/neomedia/rtcp/RTCPTCCPacketTest.java
@@ -17,6 +17,7 @@ package org.jitsi.impl.neomedia.rtcp;
 
 import org.jitsi.service.neomedia.*;
 import org.junit.*;
+import org.jitsi.util.*;
 
 import static org.junit.Assert.*;
 
@@ -86,7 +87,8 @@ public class RTCPTCCPacketTest
         before.put(130, now + 30);
         before.put(138, now + 30);
 
-        RTCPTCCPacket packet = new RTCPTCCPacket(0, 0, before, (byte) 13);
+        RTCPTCCPacket packet = new RTCPTCCPacket(
+                0, 0, before, (byte) 13, new DiagnosticContext());
 
         RTCPTCCPacket.PacketMap after = RTCPTCCPacket.getPacketsFci(new ByteArrayBufferImpl(packet.fci));
 
@@ -110,7 +112,8 @@ public class RTCPTCCPacketTest
         before.put(1273, nowMs + 18);
         before.put(1274, nowMs + 35);
 
-        RTCPTCCPacket packet = new RTCPTCCPacket(0, 0, before, (byte) 13);
+        RTCPTCCPacket packet = new RTCPTCCPacket(
+                0, 0, before, (byte) 13, new DiagnosticContext());
 
         ByteArrayBufferImpl afterBaf = new ByteArrayBufferImpl(packet.fci);
         RTCPTCCPacket.PacketMap after = RTCPTCCPacket.getPacketsFci(afterBaf);


### PR DESCRIPTION
- The first idea is to be able to mine our infra logs for valuable information and be able to correlate different logs together at the conference level or at the user level. We already to that in the JVB code and this PR enables the same logic in LJ.
- Additionally this PR also includes fixes for the send-side bandwidth estimations.