### PR TITLE
fix: Drops RTCP packets which failed to be parsed.

### DIFF
--- a/src/org/jitsi/impl/neomedia/transform/rtcp/StatisticsEngine.java
+++ b/src/org/jitsi/impl/neomedia/transform/rtcp/StatisticsEngine.java
@@ -914,7 +914,12 @@ public class StatisticsEngine
                     "Failed to analyze an incoming RTCP packet for the"
                         + " purposes of statistics.",
                     ex);
-                return pkt;
+
+                // Either this is an empty packet, or parsing failed. In any
+                // case, drop the packet to make sure we're not forwarding
+                // broken RTCP (we've observed Chrome 49 sending SRs with an
+                // incorrect 'rc' field).
+                return null;
             }
 
             try


### PR DESCRIPTION
We observed an instance in which one browser connected to jitsi-videobridge was continually sending invalid RTCP SR packets (with either 'rc' or 'length' being incorrect). The bridge would forward them (and it shouldn't forward SRs at all). This makes it drop RTCP packets when parsing fails instead.