### PR TITLE
logs: Use a separate logger for logging time series.

### DIFF
--- a/src/org/jitsi/impl/neomedia/rtp/TransportCCEngine.java
+++ b/src/org/jitsi/impl/neomedia/rtp/TransportCCEngine.java
@@ -63,10 +63,11 @@ public class TransportCCEngine
         = Logger.getLogger(TransportCCEngine.class);
 
     /**
-     * The {@link Logger} to be used by this instance to print time series.
+     * The {@link TimeSeriesLogger} to be used by this instance to print time
+     * series.
      */
-    private static final Logger timeSeriesLogger
-        = Logger.getTimeSeriesLogger(TransportCCEngine.class);
+    private static final TimeSeriesLogger timeSeriesLogger
+        = TimeSeriesLogger.getTimeSeriesLogger(TransportCCEngine.class);
 
     /**
      * The engine which handles incoming RTP packets for this instance. It
@@ -438,12 +439,12 @@ public class TransportCCEngine
             long arrivalTimeMs = arrivalTime250Us / 4
                 - remoteReferenceTimeMs + localReferenceTimeMs;
 
-            if (timeSeriesLogger.isDebugEnabled())
+            if (timeSeriesLogger.isTraceEnabled())
             {
                 if (previousArrivalTimeMs != -1)
                 {
                     long diff_ms = arrivalTimeMs - previousArrivalTimeMs;
-                    timeSeriesLogger.debug(diagnosticContext
+                    timeSeriesLogger.trace(diagnosticContext
                             .makeTimeSeriesPoint("ingress_tcc_ack")
                             .addField("seq", entry.getKey())
                             .addField("arrival_time_ms", arrivalTimeMs)
@@ -451,7 +452,7 @@ public class TransportCCEngine
                 }
                 else
                 {
-                    timeSeriesLogger.debug(diagnosticContext
+                    timeSeriesLogger.trace(diagnosticContext
                             .makeTimeSeriesPoint("ingress_tcc_ack")
                             .addField("seq", entry.getKey())
                             .addField("arrival_time_ms", arrivalTimeMs));
@@ -604,9 +605,9 @@ public class TransportCCEngine
                     ext.getOffset() + 1,
                     (short) seq);
 
-                if (timeSeriesLogger.isDebugEnabled())
+                if (timeSeriesLogger.isTraceEnabled())
                 {
-                    timeSeriesLogger.debug(diagnosticContext
+                    timeSeriesLogger.trace(diagnosticContext
                             .makeTimeSeriesPoint("egress_tcc_pkt")
                             .addField("rtp_seq", pkt.getSequenceNumber())
                             .addField("pt", RawPacket.getPayloadType(pkt))

--- a/src/org/jitsi/impl/neomedia/rtp/TransportCCEngine.java
+++ b/src/org/jitsi/impl/neomedia/rtp/TransportCCEngine.java
@@ -63,6 +63,12 @@ public class TransportCCEngine
         = Logger.getLogger(TransportCCEngine.class);
 
     /**
+     * The {@link Logger} to be used by this instance to print time series.
+     */
+    private static final Logger timeSeriesLogger
+        = Logger.getTimeSeriesLogger(TransportCCEngine.class);
+
+    /**
      * The engine which handles incoming RTP packets for this instance. It
      * reads transport-wide sequence numbers and registers arrival times.
      */
@@ -209,10 +215,10 @@ public class TransportCCEngine
             incomingPackets.put(seq, now);
         }
 
-        if (logger.isTraceEnabled())
+        if (timeSeriesLogger.isTraceEnabled())
         {
-            logger.trace(diagnosticContext
-                    .makeTimeSeriesPoint("packet_received", now)
+            timeSeriesLogger.trace(diagnosticContext
+                    .makeTimeSeriesPoint("ingress_tcc_pkt", now)
                     .addField("seq", seq)
                     .addField("pt", pt));
         }
@@ -432,23 +438,21 @@ public class TransportCCEngine
             long arrivalTimeMs = arrivalTime250Us / 4
                 - remoteReferenceTimeMs + localReferenceTimeMs;
 
-            if (logger.isDebugEnabled())
+            if (timeSeriesLogger.isDebugEnabled())
             {
                 if (previousArrivalTimeMs != -1)
                 {
                     long diff_ms = arrivalTimeMs - previousArrivalTimeMs;
-                    logger.debug(diagnosticContext
-                            .makeTimeSeriesPoint("packet_ack")
-                            .addKey("tcc_engine", hashCode())
+                    timeSeriesLogger.debug(diagnosticContext
+                            .makeTimeSeriesPoint("ingress_tcc_ack")
                             .addField("seq", entry.getKey())
                             .addField("arrival_time_ms", arrivalTimeMs)
                             .addField("diff_ms", diff_ms));
                 }
                 else
                 {
-                    logger.debug(diagnosticContext
-                            .makeTimeSeriesPoint("packet_ack")
-                            .addKey("tcc_engine", hashCode())
+                    timeSeriesLogger.debug(diagnosticContext
+                            .makeTimeSeriesPoint("ingress_tcc_ack")
                             .addField("seq", entry.getKey())
                             .addField("arrival_time_ms", arrivalTimeMs));
                 }
@@ -600,11 +604,13 @@ public class TransportCCEngine
                     ext.getOffset() + 1,
                     (short) seq);
 
-                if (logger.isDebugEnabled())
+                if (timeSeriesLogger.isDebugEnabled())
                 {
-                    logger.debug("rtp_seq=" + pkt.getSequenceNumber()
-                            + ",pt=" + RawPacket.getPayloadType(pkt)
-                            + ",tcc_seq=" + seq);
+                    timeSeriesLogger.debug(diagnosticContext
+                            .makeTimeSeriesPoint("egress_tcc_pkt")
+                            .addField("rtp_seq", pkt.getSequenceNumber())
+                            .addField("pt", RawPacket.getPayloadType(pkt))
+                            .addField("tcc_seq", seq));
                 }
 
                 synchronized (sentPacketsSyncRoot)

--- a/src/org/jitsi/impl/neomedia/rtp/remotebitrateestimator/AimdRateControl.java
+++ b/src/org/jitsi/impl/neomedia/rtp/remotebitrateestimator/AimdRateControl.java
@@ -35,12 +35,12 @@ import java.util.*;
 class AimdRateControl
 {
     /**
-     * The <tt>Logger</tt> used by the
+     * The <tt>TimeSeriesLogger</tt> used by the
      * <tt>RemoteBitrateEstimatorAbsSendTime</tt> class and its instances for
      * logging output.
      */
-    private static final Logger logger
-        = Logger.getTimeSeriesLogger(AimdRateControl.class);
+    private static final TimeSeriesLogger logger
+        = TimeSeriesLogger.getTimeSeriesLogger(AimdRateControl.class);
 
     private static final int kDefaultRttMs = 200;
 

--- a/src/org/jitsi/impl/neomedia/rtp/remotebitrateestimator/AimdRateControl.java
+++ b/src/org/jitsi/impl/neomedia/rtp/remotebitrateestimator/AimdRateControl.java
@@ -40,7 +40,7 @@ class AimdRateControl
      * logging output.
      */
     private static final Logger logger
-        = Logger.getLogger(AimdRateControl.class);
+        = Logger.getTimeSeriesLogger(AimdRateControl.class);
 
     private static final int kDefaultRttMs = 200;
 

--- a/src/org/jitsi/impl/neomedia/rtp/remotebitrateestimator/RemoteBitrateEstimatorAbsSendTime.java
+++ b/src/org/jitsi/impl/neomedia/rtp/remotebitrateestimator/RemoteBitrateEstimatorAbsSendTime.java
@@ -43,10 +43,12 @@ public class RemoteBitrateEstimatorAbsSendTime
         = Logger.getLogger(RemoteBitrateEstimatorAbsSendTime.class);
 
     /**
-     * The {@link Logger} to be used by this instance to print time series.
+     * The {@link TimeSeriesLogger} to be used by this instance to print time
+     * series.
      */
-    private static final Logger timeSeriesLogger
-        = Logger.getTimeSeriesLogger(RemoteBitrateEstimatorAbsSendTime.class);
+    private static final TimeSeriesLogger timeSeriesLogger
+        = TimeSeriesLogger.getTimeSeriesLogger(
+                RemoteBitrateEstimatorAbsSendTime.class);
 
     /**
      * Defines the number of digits in the AST representation (24 bits, 6.18

--- a/src/org/jitsi/impl/neomedia/rtp/remotebitrateestimator/RemoteBitrateEstimatorAbsSendTime.java
+++ b/src/org/jitsi/impl/neomedia/rtp/remotebitrateestimator/RemoteBitrateEstimatorAbsSendTime.java
@@ -43,6 +43,12 @@ public class RemoteBitrateEstimatorAbsSendTime
         = Logger.getLogger(RemoteBitrateEstimatorAbsSendTime.class);
 
     /**
+     * The {@link Logger} to be used by this instance to print time series.
+     */
+    private static final Logger timeSeriesLogger
+        = Logger.getTimeSeriesLogger(RemoteBitrateEstimatorAbsSendTime.class);
+
+    /**
      * Defines the number of digits in the AST representation (24 bits, 6.18
      * fixed point) after the radix.
      */
@@ -459,9 +465,9 @@ public class RemoteBitrateEstimatorAbsSendTime
         // time.
         long nowMs = System.currentTimeMillis();
 
-        if (logger.isTraceEnabled())
+        if (timeSeriesLogger.isTraceEnabled())
         {
-            logger.trace(diagnosticContext
+            timeSeriesLogger.trace(diagnosticContext
                 .makeTimeSeriesPoint("in_pkt", nowMs)
                 .addKey("rbe_id", hashCode())
                 .addField("recv_ts_ms", arrivalTimeMs)

--- a/src/org/jitsi/impl/neomedia/rtp/sendsidebandwidthestimation/SendSideBandwidthEstimation.java
+++ b/src/org/jitsi/impl/neomedia/rtp/sendsidebandwidthestimation/SendSideBandwidthEstimation.java
@@ -74,6 +74,12 @@ class SendSideBandwidthEstimation
             = Logger.getLogger(SendSideBandwidthEstimation.class);
 
     /**
+     * The {@link Logger} to be used by this instance to print time series.
+     */
+    private static final Logger timeSeriesLogger
+            = Logger.getTimeSeriesLogger(SendSideBandwidthEstimation.class);
+
+    /**
      * send_side_bandwidth_estimation.h
      */
     private long first_report_time_ms_ = -1;
@@ -225,9 +231,9 @@ class SendSideBandwidthEstimation
                 // rates).
                 bitrate += 1000;
 
-                if (logger.isTraceEnabled())
+                if (timeSeriesLogger.isTraceEnabled())
                 {
-                    logger.trace(diagnosticContext
+                    timeSeriesLogger.trace(diagnosticContext
                             .makeTimeSeriesPoint("loss_estimate", now)
                             .addField("action", "increase")
                             .addField("last_fraction_loss", last_fraction_loss_)
@@ -239,9 +245,9 @@ class SendSideBandwidthEstimation
             {
                 // Loss between 2% - 10%: Do nothing.
 
-                if (logger.isTraceEnabled())
+                if (timeSeriesLogger.isTraceEnabled())
                 {
-                    logger.trace(diagnosticContext
+                    timeSeriesLogger.trace(diagnosticContext
                             .makeTimeSeriesPoint("loss_estimate", now)
                             .addField("action", "keep")
                             .addField("last_fraction_loss", last_fraction_loss_)
@@ -265,9 +271,9 @@ class SendSideBandwidthEstimation
                         (bitrate * (512 - last_fraction_loss_)) / 512.0);
                     has_decreased_since_last_fraction_loss_ = true;
 
-                    if (logger.isTraceEnabled())
+                    if (timeSeriesLogger.isTraceEnabled())
                     {
-                        logger.trace(diagnosticContext
+                        timeSeriesLogger.trace(diagnosticContext
                                 .makeTimeSeriesPoint("loss_estimate", now)
                                 .addField("action", "decrease")
                                 .addField("last_fraction_loss", last_fraction_loss_)

--- a/src/org/jitsi/impl/neomedia/rtp/sendsidebandwidthestimation/SendSideBandwidthEstimation.java
+++ b/src/org/jitsi/impl/neomedia/rtp/sendsidebandwidthestimation/SendSideBandwidthEstimation.java
@@ -74,10 +74,12 @@ class SendSideBandwidthEstimation
             = Logger.getLogger(SendSideBandwidthEstimation.class);
 
     /**
-     * The {@link Logger} to be used by this instance to print time series.
+     * The {@link TimeSeriesLogger} to be used by this instance to print time
+     * series.
      */
-    private static final Logger timeSeriesLogger
-            = Logger.getTimeSeriesLogger(SendSideBandwidthEstimation.class);
+    private static final TimeSeriesLogger timeSeriesLogger
+            = TimeSeriesLogger.getTimeSeriesLogger(
+                    SendSideBandwidthEstimation.class);
 
     /**
      * send_side_bandwidth_estimation.h

--- a/src/org/jitsi/util/DiagnosticContext.java
+++ b/src/org/jitsi/util/DiagnosticContext.java
@@ -51,7 +51,7 @@ public class DiagnosticContext
      */
     public TimeSeriesPoint makeTimeSeriesPoint(String timeSeriesName)
     {
-        return new TimeSeriesPoint(timeSeriesName, -1);
+        return new TimeSeriesPointImpl(timeSeriesName, -1);
     }
 
     /**
@@ -63,14 +63,11 @@ public class DiagnosticContext
      */
     public TimeSeriesPoint makeTimeSeriesPoint(String timeSeriesName, long tsMs)
     {
-        return new TimeSeriesPoint(timeSeriesName, tsMs);
+        return new TimeSeriesPointImpl(timeSeriesName, tsMs);
     }
 
-    /**
-     * Represents a time series point. The <tt>toString</tt> method outputs
-     * the time series point in influx DB line protocol format.
-     */
-    public class TimeSeriesPoint
+    class TimeSeriesPointImpl
+            implements TimeSeriesPoint
     {
         private final String timeSeriesName;
 
@@ -86,7 +83,7 @@ public class DiagnosticContext
          * @param timeSeriesName the name of the time series
          * @param tsMs the timestamp of the time series point (in millis)
          */
-        public TimeSeriesPoint(String timeSeriesName, long tsMs)
+        public TimeSeriesPointImpl(String timeSeriesName, long tsMs)
         {
             this.timeSeriesName = timeSeriesName;
             this.keys = new HashMap<>(ctxKeys /* snapshot of the ctx keys */);
@@ -97,6 +94,7 @@ public class DiagnosticContext
         /**
          * Adds a key to the time series point.
          */
+        @Override
         public TimeSeriesPoint addKey(String key, Object value)
         {
             if (key != null && value != null)
@@ -109,6 +107,7 @@ public class DiagnosticContext
         /**
          * Adds a field to the time series point.
          */
+        @Override
         public TimeSeriesPoint addField(String key, Object value)
         {
             if (key != null && value != null)

--- a/src/org/jitsi/util/Logger.java
+++ b/src/org/jitsi/util/Logger.java
@@ -34,20 +34,6 @@ public abstract class Logger
      * @return a suitable Logger
      * @throws NullPointerException if the class is null.
      */
-    public static Logger getTimeSeriesLogger(Class<?> clazz)
-        throws NullPointerException
-    {
-        return getLogger("timeseries." + clazz.getName());
-    }
-
-    /**
-     * Create a logger for the specified class.
-     * <p>
-     * @param clazz The class for which to create a logger.
-     * <p>
-     * @return a suitable Logger
-     * @throws NullPointerException if the class is null.
-     */
     public static Logger getLogger(Class<?> clazz)
         throws NullPointerException
     {

--- a/src/org/jitsi/util/Logger.java
+++ b/src/org/jitsi/util/Logger.java
@@ -34,6 +34,20 @@ public abstract class Logger
      * @return a suitable Logger
      * @throws NullPointerException if the class is null.
      */
+    public static Logger getTimeSeriesLogger(Class<?> clazz)
+        throws NullPointerException
+    {
+        return getLogger("timeseries." + clazz.getName());
+    }
+
+    /**
+     * Create a logger for the specified class.
+     * <p>
+     * @param clazz The class for which to create a logger.
+     * <p>
+     * @return a suitable Logger
+     * @throws NullPointerException if the class is null.
+     */
     public static Logger getLogger(Class<?> clazz)
         throws NullPointerException
     {

--- a/src/org/jitsi/util/TimeSeriesLogger.java
+++ b/src/org/jitsi/util/TimeSeriesLogger.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright @ 2018 Atlassian Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.util;
+
+import java.util.logging.*;
+
+/**
+ * @author George Politis
+ */
+public class TimeSeriesLogger
+{
+    /**
+     * The Java logger that's going to output the time series points.
+     */
+    private final Logger logger;
+
+    /**
+     * Create a logger for the specified class.
+     * <p>
+     * @param clazz The class for which to create a logger.
+     * <p>
+     * @return a suitable Logger
+     * @throws NullPointerException if the class is null.
+     */
+    public static TimeSeriesLogger getTimeSeriesLogger(Class<?> clazz)
+        throws NullPointerException
+    {
+        String name = "timeseries." + clazz.getName();
+        Logger logger = Logger.getLogger(name);
+        return new TimeSeriesLogger(logger);
+    }
+
+    /**
+     * Ctor.
+     */
+    public TimeSeriesLogger(Logger logger)
+    {
+        this.logger = logger;
+    }
+
+    /**
+     * Check if a message with a TRACE level would actually be logged by this
+     * logger.
+     *
+     * @return true if the TRACE level is currently being logged, otherwise
+     * false.
+     */
+    public boolean isTraceEnabled()
+    {
+        return logger.isTraceEnabled();
+    }
+
+    /**
+     * Traces a {@link TimeSeriesPoint}.
+     *
+     * @param timeSeriesPoint the {@link TimeSeriesPoint} to trace.
+     */
+    public void trace(TimeSeriesPoint timeSeriesPoint)
+    {
+        logger.trace(timeSeriesPoint);
+    }
+}

--- a/src/org/jitsi/util/TimeSeriesPoint.java
+++ b/src/org/jitsi/util/TimeSeriesPoint.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright @ 2018 Atlassian Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.util;
+
+import java.util.*;
+
+/**
+ * Represents a time series point. The <tt>toString</tt> method outputs
+ * the time series point in influx DB line protocol format.
+ *
+ * @author George Politis
+ */
+public interface TimeSeriesPoint
+{
+    /**
+     * Adds a key in the time series point.
+     */
+    TimeSeriesPoint addKey(String key, Object value);
+
+    /**
+     * Adds a field in the time series point.
+     */
+    TimeSeriesPoint addField(String key, Object value);
+}


### PR DESCRIPTION
With this PR all time series can be handled separately from the general purpose logging logic:

    timeseries.level = ALL
    timeseries.org.jitsi.impl.neomedia.rtp.remotebitrateestimator.RemoteBitrateEstimatorAbsSendTime.level = OFF
    timeseries.useParentHandlers = false
    timeseries.handlers = java.util.logging.FileHandler