### PR TITLE
Send an FIR request when a non-simulcast MST becomes active

### DIFF
--- a/src/org/jitsi/impl/neomedia/rtp/MediaStreamTrackDesc.java
+++ b/src/org/jitsi/impl/neomedia/rtp/MediaStreamTrackDesc.java
@@ -218,7 +218,14 @@ public class MediaStreamTrackDesc
     {
         if (!simulcast)
         {
-            frameDesc.getRTPEncoding().setActive(true);
+            RTPEncodingDesc encoding = frameDesc.getRTPEncoding();
+            // Request an independent frame (FIR) if the stream is just becoming active.
+            if(!encoding.isActive() && pkt.getPayloadLength(true) > 0) {
+                ((RTPTranslatorImpl) mediaStreamTrackReceiver.getStream()
+                    .getRTPTranslator()).getRtcpFeedbackMessageSender()
+                    .sendFIR((int) rtpEncodings[0].getPrimarySSRC());
+            }
+            encoding.setActive(true);
             return;
         }
 


### PR DESCRIPTION
This fixes an issue where a stream sometimes wouldn't show up for recvonly users. It is a race condition between the MST becoming active and the BitrateController in the videobridge being updated which allows the stream to be forwarded on to other endpoints. Sometimes the update code runs before the stream becomes active.

Related to these issues: https://github.com/jitsi/jitsi-videobridge/issues/598, https://github.com/jitsi/jitsi-videobridge/issues/553