### PR TITLE
Do not prevent keyframe detection when throttling PLIs sent (408)

### DIFF
--- a/src/org/jitsi/impl/neomedia/rtp/MediaStreamTrackDesc.java
+++ b/src/org/jitsi/impl/neomedia/rtp/MediaStreamTrackDesc.java
@@ -222,21 +222,21 @@ public class MediaStreamTrackDesc
             return;
         }
 
-        if (nowMs - statistics.lastKeyframeMs < MIN_KEY_FRAME_WAIT_MS)
-        {
-            // The webrtc engine is sending keyframes from high to low and less
-            // often than 300 millis. The first fresh keyframe that we observe
-            // after we've waited for that long determines the streams that are
-            // streaming (not suspended).
-            //
-            // On the other hand, if this packet is not a keyframe, the only
-            // other action we can do is send an FIR and it's pointless to spam
-            // the engine.
-            return;
-        }
-
         if (!frameDesc.isIndependent())
         {
+            if (nowMs - statistics.lastKeyframeMs < MIN_KEY_FRAME_WAIT_MS)
+            {
+                // The webrtc engine is sending keyframes from high to low and less
+                // often than 300 millis. The first fresh keyframe that we observe
+                // after we've waited for that long determines the streams that are
+                // streaming (not suspended).
+                //
+                // On the other hand, if this packet is not a keyframe, the only
+                // other action we can do is send an FIR and it's pointless to spam
+                // the engine.
+                return;
+            }
+
             if (!isPacketOfNewFrame)
             {
                 // We only check for stream suspension if this is the first
@@ -308,7 +308,7 @@ public class MediaStreamTrackDesc
             {
                 // This is a late key frame header packet that we've missed.
 
-                if (!encoding.isActive())
+                if (!encoding.isActive() && !(nowMs - statistics.lastKeyframeMs < MIN_KEY_FRAME_WAIT_MS))
                 {
                     if (logger.isTraceEnabled())
                     {


### PR DESCRIPTION
When using simulcast client it receives huge number of PLIs.
This change avoids preventing keyframe detection for activation of individual simulcast RTPEngines when throttling PLIs sent

it will basically ignore any keyframes within 300ms since PLI has been sent.
First packet received will probably be intra frame so it will trigger another PLI and block keyframe detection for another 300ms.
the reason why lowest simulcast layer is marked as active is because it has highest probability of being received just in time when 300ms elapses since it's smallest in byte size.
since the other two higher layers haven't been marked as active, it will request PLI on lowest stream again... and show continues.