### PR TITLE
Align default port range for default allocation with JVB's default.

### DIFF
--- a/src/org/jitsi/service/neomedia/DefaultStreamConnector.java
+++ b/src/org/jitsi/service/neomedia/DefaultStreamConnector.java
@@ -103,7 +103,7 @@ public class DefaultStreamConnector
             bindRetries = cfg.getInt(BIND_RETRIES_PROPERTY_NAME, bindRetries);
         if (maxPort < 0)
         {
-            maxPort = 6000;
+            maxPort = 20000;
             if (cfg != null)
                 maxPort = cfg.getInt(MAX_PORT_NUMBER_PROPERTY_NAME, maxPort);
         }
@@ -112,7 +112,7 @@ public class DefaultStreamConnector
         {
             if ((minPort < 0) || (minPort > maxPort))
             {
-                minPort = 5000;
+                minPort = 10001;
                 if (cfg != null)
                 {
                     minPort


### PR DESCRIPTION
For dynamic port allocation of media streams, the videobridge uses a
default port range of 10001-20000 UDP. To avoid confusion, it would be
good if libjitsi uses the same default. Previously, libjitsi defined
5000-6000 UDP as the default range.