### PR TITLE
fixes plain VP9

### DIFF
--- a/src/org/jitsi/impl/neomedia/MediaStreamImpl.java
+++ b/src/org/jitsi/impl/neomedia/MediaStreamImpl.java
@@ -4074,6 +4074,7 @@ public class MediaStreamImpl
         }
 
         final byte vp8PT = getDynamicRTPPayloadType(Constants.VP8),
+            vp9PT = getDynamicRTPPayloadType(Constants.VP9),
             h264PT = getDynamicRTPPayloadType(Constants.H264);
 
         if (redBlock.getPayloadType() == vp8PT)
@@ -4082,6 +4083,14 @@ public class MediaStreamImpl
                 .isKeyFrame(redBlock.getBuffer(),
                             redBlock.getOffset(),
                             redBlock.getLength());
+        }
+        else if (redBlock.getPayloadType() == vp9PT)
+        {
+            return org.jitsi.impl.neomedia.codec.video.vp9.DePacketizer
+                .isKeyFrame(
+                    redBlock.getBuffer(),
+                    redBlock.getOffset(),
+                    redBlock.getLength());
         }
         else if (redBlock.getPayloadType() == h264PT)
         {

--- a/src/org/jitsi/impl/neomedia/codec/video/vp9/DePacketizer.java
+++ b/src/org/jitsi/impl/neomedia/codec/video/vp9/DePacketizer.java
@@ -15,8 +15,6 @@
  */
 package org.jitsi.impl.neomedia.codec.video.vp9;
 
-import org.jitsi.service.neomedia.*;
-
 /**
  * A depacketizer from VP9.
  * See {@link "https://tools.ietf.org/html/draft-ietf-payload-vp9-02"}
@@ -41,9 +39,24 @@ public class DePacketizer
     private static final byte L_BIT = (byte) (1 << 5);
 
     /**
+     * P bit from the first byte of the Payload Descriptor.
+     */
+    private static final byte P_BIT = (byte) (1 << 6);
+
+    /**
      * I bit from the first byte of the Payload Descriptor.
      */
     private static final byte I_BIT = (byte) (1 << 7);
+    
+    /**
+     * Mask for SID value from Layer Indices byte of the Payload Descriptor.
+     */
+    private static final byte SID_MASK = 0xE;
+    
+    /**
+     * Mask for D value from Layer Indices byte of the Payload Descriptor.
+     */
+    private static final byte D_MASK = 0x1;
 
     /**
      * A class that represents the VP9 Payload Descriptor structure defined
@@ -166,5 +179,54 @@ public class DePacketizer
 
             return (buf[loff] & 0xE) >> 1;
         }
+        
+        /**
+         * Check if the current the packet contains a key frame
+         *
+         * @param buf the byte buffer that holds the VP9 payload.
+         * @param off the offset in the byte buffer where the VP9 payload starts.
+         * @param len the length of the VP9 payload.
+         * @return true if the frame is a key frame, false otherwise
+         */
+        public static boolean isKeyFrame(byte[] buf, int off, int len)
+        {
+            // This packet will have its P bit equal to zero, SID or D
+            // bit (described below) equal to zero, and B bit (described below)
+            // equal to 1
+            
+            if (!isValid(buf, off, len))
+            {
+                return false;
+            }
+
+            // P_BIT must be 0 and B_BIT 1
+            // L_BIT must be 1 to ensure we can do further checks for SID and D
+            if((buf[off] & P_BIT) != 0 || 
+               (buf[off] & B_BIT) == 0 || 
+               (buf[off] & L_BIT) == 0 )
+            {
+                return false;
+            }
+
+            int loff = off + 1;
+            if ((buf[off] & I_BIT) != 0)
+            {
+                loff += 1;
+                if ((buf[off + 1] & (1 << 7)) != 0)
+                {
+                    // extended pid.
+                    loff += 1;
+                }
+            }
+            
+            //SID or D bit equal to zero
+            return 
+              ((buf[loff] & SID_MASK) >> 1) == 0 || (buf[loff] & D_MASK) == 0;
+        }
+    }
+
+    public static boolean isKeyFrame(byte[] buf, int off, int len)
+    {
+        return VP9PayloadDescriptor.isKeyFrame(buf, off, len);
     }
 }


### PR DESCRIPTION
Fixes jitsi/libjitsi#649
Adds key frame detection for VP9 depacketizer and uses it for independent frame detection.
