### PR TITLE
Eliminate too many CsrcAudioLevelDispatcher threads.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>ice4j</artifactId>
-      <version>2.0.0-20181210.183540-19</version>
+      <version>2.0.0-20181213.100259-20</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>ice4j</artifactId>
-      <version>2.0-20161221.230043-4</version>
+      <version>2.0.0-20181210.183540-19</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/src/org/jitsi/impl/neomedia/transform/csrc/CsrcAudioLevelDispatcher.java
+++ b/src/org/jitsi/impl/neomedia/transform/csrc/CsrcAudioLevelDispatcher.java
@@ -18,6 +18,7 @@ package org.jitsi.impl.neomedia.transform.csrc;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 
+import org.ice4j.util.*;
 import org.jitsi.impl.neomedia.*;
 
 /**
@@ -36,7 +37,9 @@ public class CsrcAudioLevelDispatcher
      * audio level updates to <tt>AudioMediaStreamImpl</tt>
      */
     private static final ExecutorService threadPool
-        = ForkJoinPool.commonPool();
+        = ExecutorFactory.createFixedThreadPool(
+            Runtime.getRuntime().availableProcessors(),
+            CsrcAudioLevelDispatcher.class.getName() + "-");
 
     /**
      * The levels added to this instance (by the <tt>reverseTransform</tt>

--- a/src/org/jitsi/impl/neomedia/transform/csrc/CsrcAudioLevelDispatcher.java
+++ b/src/org/jitsi/impl/neomedia/transform/csrc/CsrcAudioLevelDispatcher.java
@@ -57,8 +57,8 @@ public class CsrcAudioLevelDispatcher
     private final AudioMediaStreamImpl mediaStream;
 
     /**
-     * Indicates that {@link CsrcAudioLevelDispatcher} should deliver updates
-     * of audio levels to {@link #mediaStream} on separate thread.
+     * Indicates that {@link CsrcAudioLevelDispatcher} should continue delivery
+     * of audio levels updates to {@link #mediaStream} on separate thread.
      */
     private final AtomicBoolean running = new AtomicBoolean(true);
 

--- a/src/org/jitsi/impl/neomedia/transform/csrc/CsrcAudioLevelDispatcher.java
+++ b/src/org/jitsi/impl/neomedia/transform/csrc/CsrcAudioLevelDispatcher.java
@@ -16,49 +16,42 @@
 package org.jitsi.impl.neomedia.transform.csrc;
 
 import java.util.concurrent.*;
+import java.util.concurrent.atomic.*;
 
 import org.jitsi.impl.neomedia.*;
-import org.jitsi.util.*;
 
 /**
- * A simple thread that waits for new levels to be reported from incoming
- * RTP packets and then delivers them to the <tt>AudioMediaStream</tt>
- * associated with this engine. The reason we need to do this in a separate
- * thread is, of course, the time sensitive nature of incoming RTP packets.
+ * A simple dispatcher that handles new audio levels reported from incoming
+ * RTP packets and then asynchronously delivers them to associated
+ * <tt>AudioMediaStreamImpl</tt>. The asynchronous processing is necessary
+ * due to time sensitive nature of incoming RTP packets.
  *
  * @author Emil Ivov
  * @author Lyubomir Marinov
  */
 public class CsrcAudioLevelDispatcher
-    implements Runnable
 {
     /**
-     * The pool of <tt>Thread</tt>s which run
-     * <tt>CsrcAudioLevelDispatcher</tt>s.
+     * The executor service to asynchronously execute method which delivers
+     * audio level updates to <tt>AudioMediaStreamImpl</tt>
      */
     private static final ExecutorService threadPool
-        = ExecutorUtils.newCachedThreadPool(
-                true,
-                "CsrcAudioLevelDispatcher");
+        = ForkJoinPool.commonPool();
 
     /**
      * The levels added to this instance (by the <tt>reverseTransform</tt>
      * method of a <tt>PacketTransformer</tt> implementation) last.
      */
-    private long[] levels;
+    private final AtomicReference<long[]> levels
+        = new AtomicReference<>();
 
     /**
      * The <tt>AudioMediaStreamImpl</tt> which listens to this event dispatcher.
      * If <tt>null</tt>, this event dispatcher is stopped. If non-<tt>null</tt>,
      * this event dispatcher is started.
      */
-    private AudioMediaStreamImpl mediaStream;
-
-    /**
-     * The indicator which determines whether this event dispatcher has been
-     * scheduled for execution by {@link #threadPool}.
-     */
-    private boolean scheduled = false;
+    private final AtomicReference<AudioMediaStreamImpl> mediaStream
+        = new AtomicReference<>();
 
     /**
      * Initializes a new <tt>CsrcAudioLevelDispatcher</tt> to dispatch events
@@ -82,91 +75,49 @@ public class CsrcAudioLevelDispatcher
      */
     public void addLevels(long[] levels, long rtpTime)
     {
-        synchronized(this)
+        if (mediaStream.get() != null)
         {
-            this.levels = levels;
+            this.levels.set(levels);
 
-            if ((mediaStream != null) && !scheduled)
-            {
-                threadPool.execute(this);
-                scheduled = true;
-            }
-
-            notifyAll();
+            // submit asynchronous delivery of audio levels update
+            threadPool.submit(this::deliverAudioLevelsToMediaStream);
         }
     }
 
     /**
-     * Waits for new levels to be reported via the <tt>addLevels()</tt> method
-     * and then delivers them to the <tt>AudioMediaStream</tt> that we are
-     * associated with.
-     */
-    @Override
-    public void run()
-    {
-        try
-        {
-            do
-            {
-                AudioMediaStreamImpl mediaStream;
-                long[] levels;
-
-                synchronized(this)
-                {
-                    // If the mediaStream is null, this instance is to stop.
-                    mediaStream = this.mediaStream;
-                    if (mediaStream == null)
-                    {
-                        scheduled = false;
-                        break;
-                    }
-
-                    if(this.levels == null)
-                    {
-                        try { wait(); } catch (InterruptedException ie) {}
-                        continue;
-                    }
-                    else
-                    {
-                        levels = this.levels;
-                        this.levels = null;
-                    }
-                }
-
-                if(levels != null)
-                    mediaStream.audioLevelsReceived(levels);
-            }
-            while (true);
-        }
-        finally
-        {
-            synchronized (this)
-            {
-                scheduled = false;
-            }
-        }
-    }
-
-    /**
-     * Causes our run method to exit so that this thread would stop
-     * handling levels.
+     * Updates associated instance of <tt>AudioMediaStreamImpl</tt> with
+     * current dispatcher
+     * @param mediaStream - new <tt>AudioMediaStreamImpl</tt> to associate
      */
     public void setMediaStream(AudioMediaStreamImpl mediaStream)
     {
-        synchronized(this)
+        // Reset current media stream and obtain
+        AudioMediaStreamImpl oldStream
+            = this.mediaStream.getAndSet(mediaStream);
+
+        if (oldStream != mediaStream)
         {
-            if (this.mediaStream != mediaStream)
-            {
-                this.mediaStream = mediaStream;
+            /*
+             * If the mediaStream changes, it is unlikely that the (audio)
+             * levels are associated with it.
+             */
+            this.levels.set(null);
+        }
+    }
 
-                /*
-                 * If the mediaStream changes, it is unlikely that the (audio)
-                 * levels are associated with it.
-                 */
-                this.levels = null;
+    /**
+     * Delivers last reported audio levels to associated {@link #mediaStream}
+     */
+    private void deliverAudioLevelsToMediaStream()
+    {
+        final AudioMediaStreamImpl stream = mediaStream.get();
 
-                notifyAll();
-            }
+        // read and reset latest audio levels
+        final long[] latestAudioLevels = levels.getAndSet(null);
+
+        if (stream != null && latestAudioLevels != null)
+        {
+            stream.audioLevelsReceived(latestAudioLevels);
         }
     }
 }

--- a/src/org/jitsi/impl/neomedia/transform/csrc/CsrcAudioLevelDispatcher.java
+++ b/src/org/jitsi/impl/neomedia/transform/csrc/CsrcAudioLevelDispatcher.java
@@ -58,6 +58,13 @@ public class CsrcAudioLevelDispatcher
         = new AtomicReference<>();
 
     /**
+     * A cached instance of {@link #deliverAudioLevelsToMediaStream()} runnable
+     * to reduce allocations.
+     */
+    private final Runnable deliverRunnable
+        = () -> deliverAudioLevelsToMediaStream();
+
+    /**
      * Initializes a new <tt>CsrcAudioLevelDispatcher</tt> to dispatch events
      * to a specific <tt>AudioMediaStreamImpl</tt>.
      *
@@ -84,7 +91,7 @@ public class CsrcAudioLevelDispatcher
             this.levels.set(levels);
 
             // submit asynchronous delivery of audio levels update
-            threadPool.submit(this::deliverAudioLevelsToMediaStream);
+            threadPool.execute(deliverRunnable);
         }
     }
 

--- a/src/org/jitsi/impl/neomedia/transform/csrc/CsrcAudioLevelDispatcher.java
+++ b/src/org/jitsi/impl/neomedia/transform/csrc/CsrcAudioLevelDispatcher.java
@@ -29,6 +29,7 @@ import org.jitsi.impl.neomedia.*;
  *
  * @author Emil Ivov
  * @author Lyubomir Marinov
+ * @author Yura Yaroshevich
  */
 public class CsrcAudioLevelDispatcher
 {

--- a/src/org/jitsi/impl/neomedia/transform/csrc/CsrcAudioLevelDispatcher.java
+++ b/src/org/jitsi/impl/neomedia/transform/csrc/CsrcAudioLevelDispatcher.java
@@ -113,6 +113,7 @@ public class CsrcAudioLevelDispatcher
     public void close()
     {
         running.set(false);
+        levels.set(null);
     }
 
     /**

--- a/src/org/jitsi/impl/neomedia/transform/csrc/CsrcTransformEngine.java
+++ b/src/org/jitsi/impl/neomedia/transform/csrc/CsrcTransformEngine.java
@@ -151,7 +151,7 @@ public class CsrcTransformEngine
     public void close()
     {
         if (csrcAudioLevelDispatcher != null)
-            csrcAudioLevelDispatcher.setMediaStream(null);
+            csrcAudioLevelDispatcher.close();
     }
 
     /**

--- a/src/org/jitsi/impl/neomedia/transform/csrc/SsrcTransformEngine.java
+++ b/src/org/jitsi/impl/neomedia/transform/csrc/SsrcTransformEngine.java
@@ -140,7 +140,7 @@ public class SsrcTransformEngine
     public void close()
     {
         if (csrcAudioLevelDispatcher != null)
-            csrcAudioLevelDispatcher.setMediaStream(null);
+            csrcAudioLevelDispatcher.close();
     }
 
     /**


### PR DESCRIPTION
Currently there are `N` threads created by `CsrcAudioLevelDispatcher`, `1` per each incoming audio stream, for `20` conferences with `3` peers each there are `60` threads created, even so cached thread pool used. Most of the time these threads are blocked in waiting state.

This pull request rework `CsrcAudioLevelDispatcher` to use common `ForkJoinPool` to asynchronously dispatch audio level updates to media stream.