### PR TITLE
Use PacketQueue in OutputDataStreamImpl

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>ice4j</artifactId>
-      <version>2.0.0-20181217.172038-21</version>
+      <version>2.0.0-20190111.035544-25</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>ice4j</artifactId>
-      <version>2.0.0-20190111.035544-25</version>
+      <version>2.0.0-20190115.143045-26</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>ice4j</artifactId>
-      <version>2.0.0-20181213.100259-20</version>
+      <version>2.0.0-20181217.172038-21</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/src/org/jitsi/impl/neomedia/rtp/translator/OutputDataStreamImpl.java
+++ b/src/org/jitsi/impl/neomedia/rtp/translator/OutputDataStreamImpl.java
@@ -68,7 +68,7 @@ class OutputDataStreamImpl
     private static final ExecutorService writeExecutor
         = ExecutorUtils.createForkJoinPool(
             Runtime.getRuntime().availableProcessors(),
-            OutputDataStreamImpl.class.getName() + "-");
+            OutputDataStreamImpl.class.getName());
 
     /**
      * Maximum number of {@link RTPTranslatorBuffer} instances to store in

--- a/src/org/jitsi/impl/neomedia/rtp/translator/OutputDataStreamImpl.java
+++ b/src/org/jitsi/impl/neomedia/rtp/translator/OutputDataStreamImpl.java
@@ -41,6 +41,7 @@ import org.jitsi.util.Logger; // Disambiguation.
  * @author Maryam Daneshi
  * @author George Politis
  * @author Boris Grozev
+ * @author Yura Yaroshevich
  */
 class OutputDataStreamImpl
     implements OutputDataStream

--- a/src/org/jitsi/impl/neomedia/rtp/translator/OutputDataStreamImpl.java
+++ b/src/org/jitsi/impl/neomedia/rtp/translator/OutputDataStreamImpl.java
@@ -17,6 +17,7 @@ package org.jitsi.impl.neomedia.rtp.translator;
 
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.concurrent.atomic.*;
 
 import javax.media.*;
 import javax.media.rtp.*;
@@ -72,7 +73,7 @@ class OutputDataStreamImpl
     private static final int WRITE_Q_CAPACITY
         = RTPConnectorOutputStream.PACKET_QUEUE_CAPACITY;
 
-    private boolean closed;
+    private final AtomicBoolean closed = new AtomicBoolean(false);
 
     private final RTPConnectorImpl connector;
 
@@ -192,9 +193,9 @@ class OutputDataStreamImpl
         }
     }
 
-    public synchronized void close()
+    public void close()
     {
-        closed = true;
+        closed.set(true);
         writeQueue.close();
     }
 
@@ -555,7 +556,7 @@ class OutputDataStreamImpl
             Format format,
             StreamRTPManagerDesc exclusion)
     {
-        if (closed)
+        if (closed.get())
             return;
 
         RTPTranslatorBuffer buffer = buffersPool.poll();

--- a/src/org/jitsi/impl/neomedia/rtp/translator/OutputDataStreamImpl.java
+++ b/src/org/jitsi/impl/neomedia/rtp/translator/OutputDataStreamImpl.java
@@ -66,7 +66,7 @@ class OutputDataStreamImpl
      * {@link RTPTranslatorBuffer}s enqueued into {@link #writeQueue}
      */
     private static final ExecutorService writeExecutor
-        = ExecutorUtils.createForkJoinPool(
+        = ExecutorUtils.newForkJoinPool(
             Runtime.getRuntime().availableProcessors(),
             OutputDataStreamImpl.class.getName());
 

--- a/src/org/jitsi/util/ExecutorUtils.java
+++ b/src/org/jitsi/util/ExecutorUtils.java
@@ -91,7 +91,7 @@ public class ExecutorUtils
      * @param baseName - the base/prefix to use for the names of the new threads
      * or <tt>null</tt> to leave them with their default names
      */
-    public static ForkJoinPool createForkJoinPool(
+    public static ForkJoinPool newForkJoinPool(
         int parallelism, String baseName)
     {
         final ForkJoinPool.ForkJoinWorkerThreadFactory threadFactory = pool ->

--- a/src/org/jitsi/util/ExecutorUtils.java
+++ b/src/org/jitsi/util/ExecutorUtils.java
@@ -82,4 +82,30 @@ public class ExecutorUtils
                         }
                     });
     }
+
+    /**
+     * Creates a {@link ForkJoinPool} with the given parameters.
+     *
+     * @param parallelism the parallelism level. For default value,
+     * use {@link java.lang.Runtime#availableProcessors}.
+     * @param baseName - the base/prefix to use for the names of the new threads
+     * or <tt>null</tt> to leave them with their default names
+     */
+    public static ForkJoinPool createForkJoinPool(
+        int parallelism, String baseName)
+    {
+        final ForkJoinPool.ForkJoinWorkerThreadFactory threadFactory = pool ->
+        {
+            final ForkJoinWorkerThread thread
+                = ForkJoinPool
+                    .defaultForkJoinWorkerThreadFactory
+                    .newThread(pool);
+            if (baseName != null && baseName.length() > 0)
+            {
+                thread.setName(baseName + "-" + thread.getName());
+            }
+            return thread;
+        };
+        return new ForkJoinPool(parallelism, threadFactory, null, false);
+    }
 }


### PR DESCRIPTION
**TL; DR**: 
Use [`PacketQueue`](https://github.com/jitsi/ice4j/blob/master/src/main/java/org/ice4j/util/PacketQueue.java) instead of manual queue implementation in [`OutputDataStreamImpl`](https://github.com/jitsi/libjitsi/blob/master/src/org/jitsi/impl/neomedia/rtp/translator/OutputDataStreamImpl.java).

**Problem**:
There is a thread per `OutputDataStreamImpl` instance, and there are `2` `OutputDataStreamImpl` instances per `JVB` conference - one for `RTCP` and one for `RTP`. So, number of threads to serve all `OutputDataStreamImpl` instances is linear to the number of conferences.

**Solution**:
There [was a plan](https://github.com/jitsi/ice4j/blob/ce42c77b827a36dd056267aac75fbcbb5e93b556/src/main/java/org/ice4j/util/PacketQueue.java#L28) to replace manual queue within [OutputDataStreamImpl](https://github.com/jitsi/libjitsi/blob/13c82500ac35979df2d83dd48ff4082a61ded7de/src/org/jitsi/impl/neomedia/rtp/translator/OutputDataStreamImpl.java#L99) with [`PacketQueue`](https://github.com/jitsi/ice4j/blob/ce42c77b82/src/main/java/org/ice4j/util/PacketQueue.java) from `ice4j`. So this PR just implements that plan. Since than `PacketQueue` implementation were optimized to use thread borrowed from `ExecutorService` and the borrowed thread is not blocked when `PacketQueue` is empty. As a result many [thousands of `PacketsQueue` instances can share single thread](https://github.com/jitsi/ice4j/blob/ce42c77b827a36dd056267aac75fbcbb5e93b556/src/test/java/org/ice4j/util/PacketQueueTests.java#L267).
As a result this PR not only implement the original plan to replace manual queue, but also reduce overall thread usage within `JVB` instance, which results in better performance and lower packet latency.

**Pros**:
1. Simpler implementation using `PacketQueue` instead of manual queue implementation.
2. Number of thread required to run `N` `OutputDataStreamImpl` is reduced from `N` to number of cores. The `N` is doubled number of conferences hosted on `JVB` (`RTP` + `RTCP`). So, for `50` conferences there was created `100` threads to handle `OutputDataStreamImpl` items.

