### PR TITLE
Micro optimizations on hotpaths

### DIFF
--- a/src/org/jitsi/impl/neomedia/RTPConnectorInputStream.java
+++ b/src/org/jitsi/impl/neomedia/RTPConnectorInputStream.java
@@ -167,7 +167,7 @@ public abstract class RTPConnectorInputStream<T>
      * garbage collection.
      */
     private final Queue<RawPacket> rawPacketPool
-            = new LinkedBlockingQueue<>(RTPConnectorOutputStream.POOL_CAPACITY);
+            = new ArrayBlockingQueue<>(RTPConnectorOutputStream.POOL_CAPACITY);
 
     /**
      * The background/daemon <tt>Thread</tt> which invokes

--- a/src/org/jitsi/impl/neomedia/transform/SinglePacketTransformer.java
+++ b/src/org/jitsi/impl/neomedia/transform/SinglePacketTransformer.java
@@ -74,18 +74,14 @@ public abstract class SinglePacketTransformer
      * calling overhead on hotpath.
      */
     private final Function<RawPacket, RawPacket> cachedReverseTransform
-        = (pkt) -> {
-        return this.reverseTransform(pkt);
-    };
+        = pkt -> this.reverseTransform(pkt);
 
     /**
      * A cached link to {@link #transform(RawPacket)} method to reduce
      * calling overhead on hotpath.
      */
     private final Function<RawPacket, RawPacket> cachedTransform
-        = (pkt) -> {
-        return this.transform(pkt);
-    };
+        = pkt -> this.transform(pkt);
 
     /**
      * Ctor.

--- a/src/org/jitsi/impl/neomedia/transform/SinglePacketTransformer.java
+++ b/src/org/jitsi/impl/neomedia/transform/SinglePacketTransformer.java
@@ -70,6 +70,24 @@ public abstract class SinglePacketTransformer
     private final Predicate<ByteArrayBuffer> packetPredicate;
 
     /**
+     * A cached link to {@link #reverseTransform(RawPacket)} method to reduce
+     * calling overhead on hotpath.
+     */
+    private final Function<RawPacket, RawPacket> cachedReverseTransform
+        = (pkt) -> {
+        return this.reverseTransform(pkt);
+    };
+
+    /**
+     * A cached link to {@link #transform(RawPacket)} method to reduce
+     * calling overhead on hotpath.
+     */
+    private final Function<RawPacket, RawPacket> cachedTransform
+        = (pkt) -> {
+        return this.transform(pkt);
+    };
+
+    /**
      * Ctor.
      *
      * XXX At some point ideally we would get rid of this ctor and all the
@@ -125,7 +143,7 @@ public abstract class SinglePacketTransformer
     {
         return transformArray(
             pkts,
-            this::reverseTransform,
+            cachedReverseTransform,
             exceptionsInReverseTransform,
             "reverseTransform");
     }
@@ -148,7 +166,7 @@ public abstract class SinglePacketTransformer
     public RawPacket[] transform(RawPacket[] pkts)
     {
         return transformArray(
-            pkts, this::transform, exceptionsInTransform, "transform");
+            pkts, cachedTransform, exceptionsInTransform, "transform");
     }
 
     /**


### PR DESCRIPTION
**TL; DR**:
Micro-optimization applied on hotpath's found by profiling.

**Problem**:
1. According to Oracle Visual VM there is small but noticeable overhead introduced by method references used in [`reverseTransform`](https://github.com/jitsi/libjitsi/blob/cc9b594edc504c08f79f6d5a767f255671f03693/src/org/jitsi/impl/neomedia/transform/SinglePacketTransformer.java#L128) and [`transform`](https://github.com/jitsi/libjitsi/blob/cc9b594edc504c08f79f6d5a767f255671f03693/src/org/jitsi/impl/neomedia/transform/SinglePacketTransformer.java#L151);
1. A memory traffic caused by allocating new nodes by `LinkedBlockingQueue` in the [`RTPConnectorInputStream`](https://github.com/jitsi/libjitsi/blob/cc9b594edc504c08f79f6d5a767f255671f03693/src/org/jitsi/impl/neomedia/RTPConnectorInputStream.java#L170) could be avoided by using `ArrayBlockingQueue` which pre-allocates memory.

**Solution**:
1. Cache a `Function` objects calling desired method in the object field;
2. Replace `LinkedBlockingQueue` with `ArrayBlockingQueue`.