### PR TITLE
WIP: Upgrade to OpenSSL 1.1.0+.

### DIFF
--- a/src/native/openssl/HMAC.c
+++ b/src/native/openssl/HMAC.c
@@ -54,10 +54,8 @@ JNIEXPORT jlong JNICALL
 Java_org_jitsi_impl_neomedia_transform_srtp_OpenSSLHMAC_HMAC_1CTX_1create
     (JNIEnv *env, jclass clazz)
 {
-    HMAC_CTX *ctx = malloc(sizeof(HMAC_CTX));
+    HMAC_CTX *ctx = HMAC_CTX_new();
 
-    if (ctx)
-        HMAC_CTX_init(ctx);
     return (jlong) (intptr_t) ctx;
 }
 
@@ -72,8 +70,7 @@ Java_org_jitsi_impl_neomedia_transform_srtp_OpenSSLHMAC_HMAC_1CTX_1destroy
 {
     HMAC_CTX *ctx_ = (HMAC_CTX *) (intptr_t) ctx;
 
-    HMAC_CTX_cleanup(ctx_);
-    free(ctx_);
+    HMAC_CTX_free(ctx_);
 }
 
 /*

--- a/src/native/openssl/OpenSSLWrapperLoader.c
+++ b/src/native/openssl/OpenSSLWrapperLoader.c
@@ -27,8 +27,10 @@ JNIEXPORT jboolean JNICALL
 Java_org_jitsi_impl_neomedia_transform_srtp_OpenSSLWrapperLoader_OpenSSL_1Init
   (JNIEnv *env, jclass clazz)
 {
-    OpenSSL_add_all_algorithms();
-    ERR_load_crypto_strings();
+    OPENSSL_init_crypto(
+        OPENSSL_INIT_ADD_ALL_CIPHERS |
+        OPENSSL_INIT_ADD_ALL_DIGESTS | 
+        OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
 
     return JNI_TRUE;
 }

--- a/src/native/openssl/SRTPCipherCTROpenSSL.c
+++ b/src/native/openssl/SRTPCipherCTROpenSSL.c
@@ -29,9 +29,7 @@ JNIEXPORT jlong JNICALL
 Java_org_jitsi_impl_neomedia_transform_srtp_SRTPCipherCTROpenSSL_AES128CTR_1CTX_1create
   (JNIEnv *env, jclass clazz)
 {
-    EVP_CIPHER_CTX *ctx = malloc(sizeof(EVP_CIPHER_CTX));
-    if (ctx)
-        EVP_CIPHER_CTX_init(ctx);
+    EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
 
     return (jlong) (intptr_t) ctx;
 }
@@ -47,8 +45,7 @@ Java_org_jitsi_impl_neomedia_transform_srtp_SRTPCipherCTROpenSSL_AES128CTR_1CTX_
 {
     if (ctx) {
         EVP_CIPHER_CTX *ctx_ = (EVP_CIPHER_CTX *) (intptr_t) ctx;
-        EVP_CIPHER_CTX_cleanup(ctx_);
-        free(ctx_);
+        EVP_CIPHER_CTX_free(ctx_);
     }
 }
 
@@ -62,7 +59,7 @@ Java_org_jitsi_impl_neomedia_transform_srtp_SRTPCipherCTROpenSSL_AES128CTR_1CTX_
   (JNIEnv *env, jclass clazz, jlong ctx, jbyteArray key)
 {
     unsigned char key_[16];
-    (*env)->GetByteArrayRegion(env, key, 0, 16, key_);
+    (*env)->GetByteArrayRegion(env, key, 0, 16, (jbyte *) key_);
     return EVP_CipherInit_ex((EVP_CIPHER_CTX *) (intptr_t) ctx, EVP_aes_128_ctr(), NULL, key_, NULL, 1);
 }
 
@@ -77,7 +74,7 @@ Java_org_jitsi_impl_neomedia_transform_srtp_SRTPCipherCTROpenSSL_AES128CTR_1CTX_
 {
     int ok = 0;
     unsigned char iv_[16];
-    (*env)->GetByteArrayRegion(env, iv, 0, 16, iv_);
+    (*env)->GetByteArrayRegion(env, iv, 0, 16, (jbyte *) iv_);
     jbyte *inOut_;
     inOut_ = (*env)->GetPrimitiveArrayCritical(env, inOut, NULL);
     if (!inOut)


### PR DESCRIPTION
This pull request is preparation to solve #446.

The `OpenSSL` `JNI` wrapper `libjnopenssl.so` were updated to be compatible with `OpenSSL 1.1.0`.
