### PR TITLE
Use PacketQueue in RTPConnectorOutputStream

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>ice4j</artifactId>
-      <version>2.0.0-20181213.100259-20</version>
+      <version>2.0.0-20181217.172038-21</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/src/org/jitsi/impl/neomedia/RTPConnectorOutputStream.java
+++ b/src/org/jitsi/impl/neomedia/RTPConnectorOutputStream.java
@@ -851,6 +851,24 @@ public abstract class RTPConnectorOutputStream
                     return false;
                 }
             }
+
+            @Override
+            public long maxPackets()
+            {
+                return maxBuffers;
+            }
+
+            @Override
+            public long perNanos()
+            {
+                return perNanos;
+            }
+
+            @Override
+            public long maxSequentiallyProcessedPackets()
+            {
+                return 20;
+            }
         }
 
         /**

--- a/src/org/jitsi/impl/neomedia/RTPConnectorOutputStream.java
+++ b/src/org/jitsi/impl/neomedia/RTPConnectorOutputStream.java
@@ -778,11 +778,6 @@ public abstract class RTPConnectorOutputStream
                 RawPacket[] pkts;
                 try
                 {
-                    // We will sooner or later process the Buffer. Since this
-
-                    // may take a non-negligible amount of time, do it
-                    // before
-                    // taking pacing into account.
                     pkts
                         = packetize(
                             buffer.buf, 0, buffer.len,

--- a/src/org/jitsi/impl/neomedia/RTPConnectorOutputStream.java
+++ b/src/org/jitsi/impl/neomedia/RTPConnectorOutputStream.java
@@ -47,13 +47,21 @@ public abstract class RTPConnectorOutputStream
         = Logger.getLogger(RTPConnectorOutputStream.class);
 
     /**
+     * Defines minimum number of threads to have in {@link ExecutorUtils}.
+     */
+    private static final int MINIMUM_NUMBER_OF_EXECUTOR_THREADS = 8;
+
+    /**
      * Shared ExecutorService to process items put into {@link Queue}.
      * By default configure it with twice as many threads as CPU cores available
      * because operations executed in pool currently does blocking I/O.
      */
     private static final ExecutorService sharedExecutor
-        = Executors.newWorkStealingPool(
-            2 * Runtime.getRuntime().availableProcessors());
+        = ExecutorUtils.newForkJoinPool(
+            Math.max(
+                MINIMUM_NUMBER_OF_EXECUTOR_THREADS,
+                2 * Runtime.getRuntime().availableProcessors()),
+            RTPConnectorOutputStream.class.getName());
 
     /**
      * The maximum number of packets to be sent to be kept in the queue of

--- a/src/org/jitsi/impl/neomedia/RTPConnectorOutputStream.java
+++ b/src/org/jitsi/impl/neomedia/RTPConnectorOutputStream.java
@@ -537,16 +537,7 @@ public abstract class RTPConnectorOutputStream
      */
     public boolean setMaxPacketsPerMillis(int maxPackets, long perMillis)
     {
-        if (queue != null)
-        {
-            queue.setMaxPacketsPerMillis(maxPackets, perMillis);
-        }
-        else
-        {
-            logger.error("Cannot enable pacing: send thread disabled.");
-        }
-
-        return queue != null;
+        return false;
     }
 
     /**
@@ -733,31 +724,6 @@ public abstract class RTPConnectorOutputStream
         private final BufferQueue bufferQueue;
 
         /**
-         * The maximum number of {@link Buffer}s to be processed by {@link
-         * #bufferQueue} per {@link #perNanos} nanoseconds.
-         */
-        int maxBuffers = -1;
-
-        /**
-         * The time interval in nanoseconds during which no more than {@link
-         * #maxBuffers} {@link Buffer}s are to be processed by {@link
-         * #bufferQueue}.
-         */
-        long perNanos = -1;
-
-        /**
-         * The number of {@link Buffer}s already processed during the current
-         * <tt>perNanos</tt> interval.
-         */
-        long buffersProcessedInCurrentInterval = 0;
-
-        /**
-         * The time stamp in nanoseconds of the start of the current
-         * <tt>perNanos</tt> interval.
-         */
-        long intervalStartTimeNanos = 0;
-
-        /**
          * Initializes a new {@link Queue} instance and starts its send thread.
          */
         private Queue()
@@ -768,24 +734,6 @@ public abstract class RTPConnectorOutputStream
                 logger.isTraceEnabled(),
                 Queue.class.getName() + ".sendQueue",
                 new Handler());
-        }
-
-        public void setMaxPacketsPerMillis(int maxPackets, long perMillis)
-        {
-            if (maxPackets < 1)
-            {
-                // This doesn't make sense. Disable pacing.
-                this.maxBuffers = -1;
-                this.perNanos = -1;
-            }
-            else
-            {
-                if (perMillis < 1)
-                    throw new IllegalArgumentException("perMillis");
-
-                this.maxBuffers = maxPackets;
-                this.perNanos = perMillis * 1000000;
-            }
         }
 
         public void write(byte[] buf, int off, int len, Object context)

--- a/src/org/jitsi/impl/neomedia/RTPConnectorOutputStream.java
+++ b/src/org/jitsi/impl/neomedia/RTPConnectorOutputStream.java
@@ -853,18 +853,6 @@ public abstract class RTPConnectorOutputStream
             }
 
             @Override
-            public long maxPackets()
-            {
-                return maxBuffers;
-            }
-
-            @Override
-            public long perNanos()
-            {
-                return perNanos;
-            }
-
-            @Override
             public long maxSequentiallyProcessedPackets()
             {
                 return 20;


### PR DESCRIPTION
**TL; DR**: 
Use [`PacketQueue`](https://github.com/jitsi/ice4j/blob/master/src/main/java/org/ice4j/util/PacketQueue.java) instead of manual queue implementation in [`RTPConnectorOutputStream`](https://github.com/jitsi/libjitsi/blob/505f2d5b646efb2acd18bb83038d095a088a5a71/src/org/jitsi/impl/neomedia/RTPConnectorOutputStream.java#L726).

**Problem**:
There is a thread per `RTPConnectorOutputStream` instance, and there are `2` `RTPConnectorOutputStream` instances per peer in `JVB` conference - [one for `RTCP`](https://github.com/jitsi/libjitsi/blob/505f2d5b646efb2acd18bb83038d095a088a5a71/src/org/jitsi/impl/neomedia/RTPConnectorUDPImpl.java#L104) and [one for `RTP`](https://github.com/jitsi/libjitsi/blob/505f2d5b646efb2acd18bb83038d095a088a5a71/src/org/jitsi/impl/neomedia/RTPConnectorUDPImpl.java#L132). So, number of threads to serve all `RTPConnectorOutputStream` instances is linear to the number of peers!

**Solution**:
There [was a plan](https://github.com/jitsi/ice4j/blob/e3e78dcda3f791598f6dde256fbaba8ffc2399a3/src/main/java/org/ice4j/util/PacketQueue.java#L26) to replace manual queue within [RTPConnectorOutputStream](https://github.com/jitsi/libjitsi/blob/505f2d5b646efb2acd18bb83038d095a088a5a71/src/org/jitsi/impl/neomedia/RTPConnectorOutputStream.java#L726) with [`PacketQueue`](https://github.com/jitsi/ice4j/blob/ce42c77b82/src/main/java/org/ice4j/util/PacketQueue.java) from `ice4j`. So this PR just implements that plan. Since than `PacketQueue` implementation were optimized to use thread borrowed from `ExecutorService` and the borrowed thread is not blocked when `PacketQueue` is empty. As a result many [thousands of `PacketsQueue` instances can share single thread](https://github.com/jitsi/ice4j/blob/ce42c77b827a36dd056267aac75fbcbb5e93b556/src/test/java/org/ice4j/util/PacketQueueTests.java#L267).
As a result this PR not only implement the original plan to replace manual queue, but also **reduce overall thread usage within `JVB` instance**, which results in better performance and lower packet latency.

**Pros**:
1. Simpler implementation using `PacketQueue` instead of manual queue implementation.
2. Number of thread required to run `N` `RTPConnectorOutputStream` is reduced from `N` to `2x` number of cores. The `N` is doubled number of peers connected to `JVB` (`RTP` + `RTCP`). So, for `150` peers connected to `JVB` there was created `300` threads to handle `RTPConnectorOutputStream` items.
