### PR TITLE
Fixes AbstractRTPPacketPredicate.test()

### DIFF
--- a/src/org/jitsi/impl/neomedia/AbstractRTPPacketPredicate.java
+++ b/src/org/jitsi/impl/neomedia/AbstractRTPPacketPredicate.java
@@ -27,13 +27,6 @@ public class AbstractRTPPacketPredicate
     implements Predicate<ByteArrayBuffer>
 {
     /**
-     * The <tt>Logger</tt> used by the <tt>AbstractRTPPacketPredicate</tt>
-     * class.
-     */
-    private static final Logger logger
-        = Logger.getLogger(AbstractRTPPacketPredicate.class);
-
-    /**
      * True if this predicate should test for RTCP, false for RTP.
      */
     private final boolean rtcp;
@@ -43,7 +36,7 @@ public class AbstractRTPPacketPredicate
      *
      * @param rtcp true if this predicate should test for RTCP, false for RTP.
      */
-    public AbstractRTPPacketPredicate(boolean rtcp)
+    AbstractRTPPacketPredicate(boolean rtcp)
     {
         this.rtcp = rtcp;
     }
@@ -54,9 +47,8 @@ public class AbstractRTPPacketPredicate
     @Override
     public boolean test(ByteArrayBuffer pkt)
     {
-        // If isHeaderValid fails, this is not a valid RTP packet either.
         if (pkt == null
-                || !RTCPUtils.isHeaderValid(
+                || RawPacket.isInvalid(
                     pkt.getBuffer(), pkt.getOffset(), pkt.getLength()))
         {
             return false;

--- a/src/org/jitsi/impl/neomedia/transform/DiscardTransformEngine.java
+++ b/src/org/jitsi/impl/neomedia/transform/DiscardTransformEngine.java
@@ -138,7 +138,7 @@ public class DiscardTransformEngine
 
             // Check RTCP packet validity. This makes sure that pktLen > 0
             // so this loop will eventually terminate.
-            if (!RTCPUtils.isHeaderValid(buf, offset, length))
+            if (!RTCPUtils.isRtcp(buf, offset, length))
             {
                 return pkt;
             }

--- a/src/org/jitsi/impl/neomedia/transform/REDTransformEngine.java
+++ b/src/org/jitsi/impl/neomedia/transform/REDTransformEngine.java
@@ -155,7 +155,7 @@ public class REDTransformEngine
 
         for (RawPacket pkt : pkts)
         {
-            if (pkt != null && pkt.getVersion() == RTPHeader.VERSION)
+            if (pkt != null && !pkt.isInvalid())
             {
                 byte[] buf = pkt.getBuffer();
                 int len = pkt.getLength();

--- a/src/org/jitsi/impl/neomedia/transform/csrc/CsrcTransformEngine.java
+++ b/src/org/jitsi/impl/neomedia/transform/csrc/CsrcTransformEngine.java
@@ -288,7 +288,7 @@ public class CsrcTransformEngine
     public synchronized RawPacket transform(RawPacket pkt)
     {
         // Only transform RTP packets (and not ZRTP/DTLS, etc)
-        if (pkt == null || pkt.getVersion() != RTPHeader.VERSION)
+        if (pkt == null || pkt.isInvalid())
             return pkt;
 
         long[] csrcList = mediaStream.getLocalContributingSourceIDs();

--- a/src/org/jitsi/impl/neomedia/transform/csrc/SsrcTransformEngine.java
+++ b/src/org/jitsi/impl/neomedia/transform/csrc/SsrcTransformEngine.java
@@ -213,8 +213,7 @@ public class SsrcTransformEngine
 
         if ((ssrcAudioLevelExtID > 0)
                 && ssrcAudioLevelDirection.allowsReceiving()
-                && !pkt.isInvalid()
-                && RTPHeader.VERSION == pkt.getVersion())
+                && !pkt.isInvalid())
         {
             byte level = pkt.extractSsrcAudioLevel(ssrcAudioLevelExtID);
 

--- a/src/org/jitsi/impl/neomedia/transform/dtmf/DtmfTransformEngine.java
+++ b/src/org/jitsi/impl/neomedia/transform/dtmf/DtmfTransformEngine.java
@@ -286,7 +286,7 @@ public class DtmfTransformEngine
     {
         if (currentTone.isEmpty()
                 || pkt == null
-                || pkt.getVersion() != RTPHeader.VERSION)
+                || pkt.isInvalid())
         {
             return pkt;
         }

--- a/src/org/jitsi/impl/neomedia/transform/fec/FECSender.java
+++ b/src/org/jitsi/impl/neomedia/transform/fec/FECSender.java
@@ -100,7 +100,7 @@ class FECSender
         RawPacket pkt = null;
         for (RawPacket p : pkts)
         {
-            if (p != null && p.getVersion() == RTPHeader.VERSION)
+            if (p != null && !p.isInvalid())
             {
                 pkt = p;
                 break;

--- a/src/org/jitsi/impl/neomedia/transform/pt/PayloadTypeTransformEngine.java
+++ b/src/org/jitsi/impl/neomedia/transform/pt/PayloadTypeTransformEngine.java
@@ -66,7 +66,7 @@ public class PayloadTypeTransformEngine
     {
         if (mappingOverridesCopy == null
                 || mappingOverridesCopy.isEmpty()
-                || pkt.getVersion() != RTPHeader.VERSION)
+                || pkt.isInvalid())
         {
             return pkt;
         }

--- a/src/org/jitsi/service/neomedia/RawPacket.java
+++ b/src/org/jitsi/service/neomedia/RawPacket.java
@@ -61,6 +61,11 @@ public class RawPacket
     private static final int RTCP_MIN_SIZE = 8;
 
     /**
+     * The value of the version field for RTCP packets.
+     */
+    private static final int VERSION = 2;
+
+    /**
      * The bitmask for the RTP sequence number field.
      */
     public static final int SEQUENCE_NUMBER_MASK = 0xffff;
@@ -161,30 +166,6 @@ public class RawPacket
     }
 
     /**
-     * Gets the value of the "version" field of an RTP packet.
-     * @return the value of the RTP "version" field.
-     */
-    public static int getVersion(ByteArrayBuffer baf)
-    {
-        if (baf == null)
-        {
-            return -1;
-        }
-
-        return getVersion(baf.getBuffer(), baf.getOffset(), baf.getLength());
-    }
-
-
-    /**
-     * Gets the value of the "version" field of an RTP packet.
-     * @return the value of the RTP "version" field.
-     */
-    public static int getVersion(byte[] buffer, int offset, int length)
-    {
-        return (buffer[offset] & 0xC0) >>> 6;
-    }
-
-    /**
      * Test whether the RTP Marker bit is set
      *
      * @param baf
@@ -220,7 +201,7 @@ public class RawPacket
     }
 
     /**
-     * Perform checks on the packet represented by this instance and
+     * Perform checks on the RTP/RTCP packet represented by this instance and
      * return <tt>true</tt> if it is found to be invalid. A return value of
      * <tt>false</tt> does not necessarily mean that the packet is valid.
      *
@@ -229,9 +210,17 @@ public class RawPacket
      */
     public static boolean isInvalid(byte[] buffer, int offset, int length)
     {
+        // XXX A better name for this method might be isRtpRtcp.
+
         // RTP packets are at least 12 bytes long, RTCP packets can be 8.
         if (buffer == null || buffer.length < offset + length
             || length < RTCP_MIN_SIZE)
+        {
+            return true;
+        }
+
+        int version = (buffer[offset] & 0xC0) >>> 6;
+        if (version != VERSION)
         {
             return true;
         }
@@ -1023,15 +1012,6 @@ public class RawPacket
     }
 
     /**
-     * Gets the value of the "version" field of an RTP packet.
-     * @return the value of the RTP "version" field.
-     */
-    public int getVersion()
-    {
-        return getVersion(buffer, offset, length);
-    }
-
-    /**
      * Get RTP padding size from a RTP packet
      *
      * @return RTP padding size from source RTP packet
@@ -1467,6 +1447,7 @@ public class RawPacket
     @Override
     public boolean isInvalid()
     {
+        // XXX A better name for this method might be isRtpRtcp.
         return isInvalid(buffer, offset, length);
     }
 
@@ -1854,18 +1835,10 @@ public class RawPacket
 
     /**
      * Sets the RTP version in this RTP packet.
-     *
-     * @return the number of bytes that were written, or -1 in case of an error.
      */
-    public boolean setVersion()
+    private void setVersion()
     {
-        if (isInvalid())
-        {
-            return false;
-        }
-
         buffer[offset] |= 0x80;
-        return true;
     }
 
     /**

--- a/src/org/jitsi/util/RTCPUtils.java
+++ b/src/org/jitsi/util/RTCPUtils.java
@@ -25,33 +25,31 @@ import org.jitsi.service.neomedia.*;
 public class RTCPUtils
 {
     /**
-     * The values of the Version field for RTCP packets.
-     */
-    public static int VERSION = 2;
-
-    /**
-     * The size in bytes of the smallest possible RTCP packet (e.g. an empty
-     * Receiver Report).
-     */
-    public static int MIN_SIZE = 8;
-
-    /**
-     * Gets the RTCP packet type.
-     *
      * @param buf the byte buffer that contains the RTCP header.
      * @param off the offset in the byte buffer where the RTCP header starts.
      * @param len the number of bytes in buffer which constitute the actual
      * data.
-     * @return the unsigned RTCP packet type, or -1 in case of an error.
+     * @return the packet type (as an unsigned int) of the RTCP packet that is
+     * specified as an argument, if it's an RTCP packet, -1 otherwise.
      */
     public static int getPacketType(byte[] buf, int off, int len)
     {
-        if (!isHeaderValid(buf, off, len))
+        if (RawPacket.isInvalid(buf, off, len))
         {
             return -1;
         }
 
-        return buf[off + 1] & 0xff;
+        int pt = buf[off + 1] & 0xff;
+
+        // Other packet types are used for RTP.
+        if (200 <= pt && pt <= 211)
+        {
+            return pt;
+        }
+        else
+        {
+            return -1;
+        }
     }
 
     /**
@@ -70,29 +68,6 @@ public class RTCPUtils
         return getPacketType(baf.getBuffer(), baf.getOffset(), baf.getLength());
     }
 
-
-    /**
-     * Sets the RTCP sender SSRC.
-     *
-     * @param buf the byte buffer that contains the RTCP header.
-     * @param off the offset in the byte buffer where the RTCP header starts.
-     * @param len the number of bytes in buffer which constitute the actual
-     * data.
-     * @param senderSSRC the sender SSRC to set.
-     * @return the number of bytes that were written to the byte buffer, or -1
-     * in case of an error.
-     */
-    private static int setSenderSSRC(
-        byte[] buf, int off, int len, int senderSSRC)
-    {
-        if (!isHeaderValid(buf, off, len))
-        {
-            return -1;
-        }
-
-        return RTPUtils.writeInt(buf, off + 4, senderSSRC);
-    }
-
     /**
      * Gets the RTCP packet length in bytes as specified by the length field
      * of the RTCP packet (does not verify that the buffer is actually large
@@ -106,8 +81,7 @@ public class RTCPUtils
      */
     public static int getLength(byte[] buf, int off, int len)
     {
-        // XXX Do not check with isHeaderValid.
-        if (buf == null || buf.length < off + len || len < 4)
+        if (!isRtcp(buf, off, len))
         {
             return -1;
         }
@@ -116,74 +90,6 @@ public class RTCPUtils
             = ((buf[off + 2] & 0xff) << 8) | (buf[off + 3] & 0xff);
 
         return (lengthInWords + 1) * 4;
-    }
-
-    /**
-     * Gets the RTCP packet version.
-     *
-     * @param buf the byte buffer that contains the RTCP header.
-     * @param off the offset in the byte buffer where the RTCP header starts.
-     * @param len the number of bytes in buffer which constitute the actual
-     * data.
-     * @return the RTCP packet version, or -1 in case of an error.
-     */
-    public static int getVersion(byte[] buf, int off, int len)
-    {
-        // XXX Do not check with isHeaderValid.
-        if (buf == null || buf.length < off + len || len < 1)
-        {
-            return -1;
-        }
-
-        return (buf[off] & 0xc0) >>> 6;
-    }
-
-    /**
-     * Checks whether the RTCP header is valid or not (note that a valid header
-     * does not necessarily imply a valid packet). It does so by checking
-     * the RTCP header version and makes sure the buffer is at least 8 bytes
-     * long.
-     *
-     * @param buf the byte buffer that contains the RTCP header.
-     * @param off the offset in the byte buffer where the RTCP header starts.
-     * @param len the number of bytes in buffer which constitute the actual
-     * data.
-     * @return true if the RTCP packet is valid, false otherwise.
-     */
-    public static boolean isHeaderValid(byte[] buf, int off, int len)
-    {
-        int version = RTCPUtils.getVersion(buf, off, len);
-        if (version != VERSION)
-        {
-            return false;
-        }
-
-        int pktLen = RTCPUtils.getLength(buf, off, len);
-        if (pktLen < MIN_SIZE)
-        {
-            return false;
-        }
-
-        return true;
-    }
-
-    /**
-     * Sets the RTCP sender SSRC.
-     *
-     * @param baf the {@link ByteArrayBuffer} that contains the RTCP header.
-     * @param senderSSRC the sender SSRC to set.
-     * @return the number of bytes that were written to the byte buffer, or -1
-     * in case of an error.
-     */
-    public static int setSenderSSRC(ByteArrayBuffer baf, int senderSSRC)
-    {
-        if (baf == null)
-        {
-            return -1;
-        }
-
-        return setSenderSSRC(
-            baf.getBuffer(), baf.getOffset(), baf.getLength(), senderSSRC);
     }
 
     /**
@@ -220,7 +126,7 @@ public class RTCPUtils
      */
     private static int getReportCount(byte[] buf, int off, int len)
     {
-        if (buf == null || buf.length < off + len || len < 1)
+        if (!isRtcp(buf, off, len))
         {
             return -1;
         }
@@ -259,15 +165,7 @@ public class RTCPUtils
      */
     public static boolean isRtcp(byte[] buf, int off, int len)
     {
-        if (!isHeaderValid(buf, off, len))
-        {
-            return false;
-        }
-
-        int pt = getPacketType(buf, off, len);
-
-        // Other packet types are used for RTP.
-        return 200 <= pt && pt <= 211;
+        return getPacketType(buf, off, len) != -1;
     }
 
 }


### PR DESCRIPTION
as it was returning false for RTP packets with sequence number 0. It also removes some unused code.