### PR TITLE
RecorderRtpImpl.java is constructing an instance of the inner class

### DIFF
--- a/src/org/jitsi/impl/neomedia/recording/RecorderRtpImpl.java
+++ b/src/org/jitsi/impl/neomedia/recording/RecorderRtpImpl.java
@@ -328,6 +328,14 @@ public class RecorderRtpImpl
         }
 
         /*
+         * Register a fake call participant.
+         * TODO: can we use a more generic MediaStream here?
+         */
+        mediaStream
+            = mediaService.createMediaStream(new MediaDeviceImpl(
+                        new CaptureDeviceInfo(), MediaType.VIDEO));
+
+        /*
          * Note that we use only one RTPConnector for both the RTPTranslator
          * and the RTPManager instances. The this.translator will write to its
          * output streams, and this.rtpManager will read from its input streams.
@@ -350,13 +358,6 @@ public class RecorderRtpImpl
          */
         rtpManager.initialize(rtpConnector);
 
-        /*
-         * Register a fake call participant.
-         * TODO: can we use a more generic MediaStream here?
-         */
-        mediaStream
-            = mediaService.createMediaStream(new MediaDeviceImpl(
-                        new CaptureDeviceInfo(), MediaType.VIDEO));
         streamRTPManager = new StreamRTPManager(mediaStream, translator);
 
         streamRTPManager.initialize(rtpConnector);


### PR DESCRIPTION
RTPConnectorImpl, which when constructed creates a new
FECTransformEngine instance, passing in the current value of
mediaStream, which is null and initialized afterwards.

This is probably what is causing the issue in this following forum post
regarding jigasi:
https://community.jitsi.org/t/problems-implementing-rtptanslation-in-jigasi-for-transcriptiongateway/15744

And I am wanting to internally use the old Colibri recording method,
which I realize is no longer supported, but I think this is just plainly
broken, and maybe has other implications.