### PR TITLE
Debug logging of packet mishandling round 2

### DIFF
--- a/src/org/jitsi/impl/neomedia/codec/video/vp8/DePacketizer.java
+++ b/src/org/jitsi/impl/neomedia/codec/video/vp8/DePacketizer.java
@@ -800,7 +800,7 @@ public class DePacketizer
                 ", pid=" + getPictureId(buf, off) +
                 ", isExtended=" + hasExtendedPictureId(buf, off, len) +
                 ", hex=" +
-                RTPUtils.toHexString(buf, off, Math.min(len, MAX_LENGTH)) +
+                RTPUtils.toHexString(buf, off, Math.min(len, MAX_LENGTH), false) +
                 "]";
         }
     }

--- a/src/org/jitsi/impl/neomedia/rtp/MediaStreamTrackDesc.java
+++ b/src/org/jitsi/impl/neomedia/rtp/MediaStreamTrackDesc.java
@@ -17,7 +17,6 @@ package org.jitsi.impl.neomedia.rtp;
 
 import org.jitsi.service.neomedia.*;
 import org.jitsi.utils.*;
-import org.jitsi.utils.logging.*;
 
 /**
  * Represents a collection of {@link RTPEncodingDesc}s that encode the same
@@ -28,13 +27,6 @@ import org.jitsi.utils.logging.*;
  */
 public class MediaStreamTrackDesc
 {
-    /**
-     * The {@link Logger} used by the {@link MediaStreamTrackDesc} class
-     * to print debug information.
-     */
-    private static final Logger logger
-        = Logger.getLogger(MediaStreamTrackDesc.class);
-
     /**
      * The {@link RTPEncodingDesc}s that this {@link MediaStreamTrackDesc}
      * possesses, ordered by their subjective quality from low to high.
@@ -166,9 +158,6 @@ public class MediaStreamTrackDesc
     {
         if (ArrayUtils.isNullOrEmpty(rtpEncodings))
         {
-            logger.warn("Empty encodings array, can't match pkt with " +
-                mediaStreamTrackReceiver
-                    .getStream().packetToString(pkt));
             return null;
         }
 
@@ -179,11 +168,6 @@ public class MediaStreamTrackDesc
                 return encoding;
             }
         }
-
-        logger.warn("Failed to match an encoding for pkt with " +
-            mediaStreamTrackReceiver
-                .getStream().packetToString(pkt) +
-                " to an encoding. Available encodings " + this);
 
         return null;
     }

--- a/src/org/jitsi/impl/neomedia/rtp/MediaStreamTrackReceiver.java
+++ b/src/org/jitsi/impl/neomedia/rtp/MediaStreamTrackReceiver.java
@@ -19,7 +19,6 @@ import org.jitsi.impl.neomedia.*;
 import org.jitsi.impl.neomedia.transform.*;
 import org.jitsi.service.neomedia.*;
 import org.jitsi.utils.*;
-import org.jitsi.utils.logging.*;
 
 /**
  * Contains the {@link MediaStreamTrackDesc}s for a {@link MediaStream}. It
@@ -36,13 +35,6 @@ public class MediaStreamTrackReceiver
     extends SinglePacketTransformerAdapter
     implements TransformEngine
 {
-    /**
-     * The {@link Logger} used by the {@link SinglePacketTransformerAdapter} class
-     * to print debug information.
-     */
-    private static final Logger logger
-        = Logger.getLogger(MediaStreamTrackReceiver.class);
-
     /**
      * An empty array of {@link MediaStreamTrackDesc}.
      */
@@ -86,8 +78,6 @@ public class MediaStreamTrackReceiver
         MediaStreamTrackDesc[] localTracks = tracks;
         if (ArrayUtils.isNullOrEmpty(localTracks))
         {
-            logger.warn("Empty tracks array, can't match pkt with "
-                + stream.packetToString(pkt));
             return null;
         }
 

--- a/src/org/jitsi/util/RTPUtils.java
+++ b/src/org/jitsi/util/RTPUtils.java
@@ -346,7 +346,7 @@ public class RTPUtils
      */
     public static String toHexString(byte[] buf)
     {
-        return toHexString(buf, 0, buf.length);
+        return toHexString(buf, 0, buf.length, true);
     }
 
     /**
@@ -357,6 +357,20 @@ public class RTPUtils
      * @return
      */
     public static String toHexString(byte[] buf, int off, int len)
+    {
+        return toHexString(buf, off, len, true);
+    }
+
+    /**
+     * Return a string containing the hex string version of the given byte
+     * @param buf
+     * @param off
+     * @param len
+     * @param format a boolean that indicates whether or not to format the hex
+     * string.
+     * @return
+     */
+    public static String toHexString(byte[] buf, int off, int len, boolean format)
     {
         if (buf == null)
         {
@@ -369,15 +383,18 @@ public class RTPUtils
 
             for (int i = 0; i < len; i++)
             {
-                if (i % 16 == 0)
+                if (format)
                 {
-                    hexStringBuilder.append("\n")
-                        .append(toHexString((byte)i))
-                        .append("  ");
-                }
-                else if (i % 8 == 0)
-                {
-                    hexStringBuilder.append(" ");
+                    if (i % 16 == 0)
+                    {
+                        hexStringBuilder.append("\n")
+                            .append(toHexString((byte) i))
+                            .append("  ");
+                    }
+                    else if (i % 8 == 0)
+                    {
+                        hexStringBuilder.append(" ");
+                    }
                 }
                 byte b = buf[off + i];
 


### PR DESCRIPTION
partially reverts 96ffe607. 96ffe607 adds some logging around rtp encodings matching that has some negative side effects. The logging logic is best suited for the caller so it has been/will be moved there.