### PR TITLE
build: Make sure OpenSSL is linked in Shared Library.

### DIFF
--- a/src/native/build.xml
+++ b/src/native/build.xml
@@ -1467,7 +1467,7 @@
       <linkerarg value="-m64" if="cross_64" />
 
       <linkerarg value="-Wl,-z,relro" if="is.running.debian"/>
-      <linkerarg value="-lcrypto"/>
+      <linkerarg value="-lcrypto" location="end"/>
 
       <fileset dir="${src}/native/openssl" includes="*.c"/>
 


### PR DESCRIPTION
Otherwise, the resulting shared library may end-up without a link to libcrypto.so.