### PR TITLE
AMR: Send correct timestamp in RTP packets.

### DIFF
--- a/src/org/jitsi/impl/neomedia/codec/audio/amrwb/JNIEncoder.java
+++ b/src/org/jitsi/impl/neomedia/codec/audio/amrwb/JNIEncoder.java
@@ -202,4 +202,48 @@ public class JNIEncoder
         }
         return format;
     }
+    
+        /**
+     * Gets the <tt>Format</tt> of the media output by this <tt>Codec</tt>.
+     *
+     * @return the <tt>Format</tt> of the media output by this <tt>Codec</tt>
+     * @see net.sf.fmj.media.AbstractCodec#getOutputFormat()
+     */
+    @Override
+    @SuppressWarnings("serial") /* copied from Speex and Opus Codec */
+    public Format getOutputFormat()
+    {
+        Format f = super.getOutputFormat();
+
+        if ((f != null) && (f.getClass() == AudioFormat.class))
+        {
+            AudioFormat af = (AudioFormat) f;
+
+            f
+                = setOutputFormat(
+                        new AudioFormat(
+                                    af.getEncoding(),
+                                    af.getSampleRate(),
+                                    af.getSampleSizeInBits(),
+                                    af.getChannels(),
+                                    af.getEndian(),
+                                    af.getSigned(),
+                                    af.getFrameSizeInBits(),
+                                    af.getFrameRate(),
+                                    af.getDataType())
+                                {
+                                    @Override
+                                    public long computeDuration(long length)
+                                    {
+                                        /*
+                                           current implementation provides only single frames,
+                                           see frame type index above; therefore static 20ms
+                                        */
+                                        return 20L /* milliseconds */
+                                                   * 1000000L /* nanoseconds in a millisecond */;
+                                    }
+                                });
+        }
+        return f;
+    }
 }

--- a/src/org/jitsi/impl/neomedia/codec/audio/amrwb/JNIEncoder.java
+++ b/src/org/jitsi/impl/neomedia/codec/audio/amrwb/JNIEncoder.java
@@ -78,6 +78,14 @@ public class JNIEncoder
         };
 
     /**
+     *  The current implementation provides only single frames with 20ms size,
+     *  see {@link #doProcess(Buffer, Buffer)}.
+     */
+    private static final long durationNanos
+            = 20L /* milliseconds */
+                * 1000_000L /* nanoseconds in a millisecond */;
+
+    /**
      * The bit rate to be produced by this <tt>JNIEncoder</tt>.
      */
     private int bitRate = BIT_RATES[BIT_RATES.length - 1];
@@ -173,9 +181,7 @@ public class JNIEncoder
         }
 
         buf.setData(dst);
-        buf.setDuration(
-                20L /* milliseconds */
-                    * 1000000L /* nanoseconds in a millisecond */);
+        buf.setDuration(durationNanos);
         buf.setLength(dstLen);
         buf.setOffset(0);
 
@@ -235,12 +241,7 @@ public class JNIEncoder
                                     @Override
                                     public long computeDuration(long length)
                                     {
-                                        /*
-                                           current implementation provides only single frames,
-                                           see frame type index above; therefore static 20ms
-                                        */
-                                        return 20L /* milliseconds */
-                                                   * 1000000L /* nanoseconds in a millisecond */;
+                                        return durationNanos;
                                     }
                                 });
         }


### PR DESCRIPTION
AudioFormat.computeDuration(.) of the Java Media Framework (JMF) returns -1 on default. Therefore, the timestamp in RTP started with 0xffff and decreased by one with each packet. Now, the timestamp increases 320 with every packet (because just a single AMR-WB frame is included in each packet).

fixes jitsi/jitsi#613