### PR TITLE
AMR: Detect it within FFmpeg at Runtime.

### DIFF
--- a/src/org/jitsi/impl/neomedia/MediaUtils.java
+++ b/src/org/jitsi/impl/neomedia/MediaUtils.java
@@ -239,13 +239,35 @@ public class MediaUtils
                 opusAdvancedParams,
                 48000);
 
-        // Adaptive Multi-Rate Wideband (AMR-WB)
-        addMediaFormats(
-                MediaFormat.RTP_PAYLOAD_TYPE_UNKNOWN,
-                Constants.AMR_WB,
-                MediaType.AUDIO,
-                Constants.AMR_WB_RTP,
-                16000);
+        boolean enableFfmpeg
+            = cfg.getBoolean(MediaService.ENABLE_FFMPEG_CODECS_PNAME, false);
+
+        /* AMR-WB (Adaptive Multi-Rate Wideband) */
+        // Checks whether ffmpeg is enabled and whether AMR-WB is available in
+        // the provided binaries
+        boolean amrwbEnabled = false;
+        if (enableFfmpeg)
+        {
+            try
+            {
+                amrwbEnabled
+                    = FFmpeg.avcodec_find_encoder(FFmpeg.CODEC_ID_AMR_WB) != 0;
+            }
+            catch (Throwable t)
+            {
+                logger.debug("AMR-WB codec not found", t);
+            }
+        }
+
+        if (amrwbEnabled)
+        {
+            addMediaFormats(
+                    MediaFormat.RTP_PAYLOAD_TYPE_UNKNOWN,
+                    Constants.AMR_WB,
+                    MediaType.AUDIO,
+                    Constants.AMR_WB_RTP,
+                    16000);
+        }
 
         /*
          * We don't really support these.
@@ -270,8 +292,6 @@ public class MediaUtils
         /* H264 */
         // Checks whether ffmpeg is enabled and whether h264 is available in
         // the provided binaries
-        boolean enableFfmpeg
-            = cfg.getBoolean(MediaService.ENABLE_FFMPEG_CODECS_PNAME, false);
         boolean h264Enabled = false;
         if (enableFfmpeg)
         {

--- a/src/org/jitsi/impl/neomedia/codec/FMJPlugInConfiguration.java
+++ b/src/org/jitsi/impl/neomedia/codec/FMJPlugInConfiguration.java
@@ -109,8 +109,8 @@ public class FMJPlugInConfiguration
             //"org.jitsi.impl.neomedia.codec.video.h263p.Packetizer",
             // Adaptive Multi-Rate Wideband (AMR-WB)
             // "org.jitsi.impl.neomedia.codec.audio.amrwb.DePacketizer",
-            //"org.jitsi.impl.neomedia.codec.audio.amrwb.JNIDecoder",
-            //"org.jitsi.impl.neomedia.codec.audio.amrwb.JNIEncoder",
+            "org.jitsi.impl.neomedia.codec.audio.amrwb.JNIDecoder",
+            "org.jitsi.impl.neomedia.codec.audio.amrwb.JNIEncoder",
             // "org.jitsi.impl.neomedia.codec.audio.amrwb.Packetizer",
         };
 

--- a/src/org/jitsi/impl/neomedia/codec/FMJPlugInConfiguration.java
+++ b/src/org/jitsi/impl/neomedia/codec/FMJPlugInConfiguration.java
@@ -275,10 +275,13 @@ public class FMJPlugInConfiguration
                 }
                 else
                 {
-                    logger.warn(
+                    if (logger.isTraceEnabled())
+                    {
+                        logger.trace(
                             "Codec " + className
                                 + " is NOT successfully registered",
                             exception);
+                    }
                 }
             }
         }


### PR DESCRIPTION
OpenH264 is an extension to FFmpeg. The bundled FFmpeg for Microsoft Windows includes support for the video codec H.264. However, that bundled FFmpeg does not come with the audio codec AMR(-WB). The change for OpenH264 simply disabled AMR-WB in general, at compile time (see #403 Review 97453424). Beside losing AMR-WB, that change was incomplete because AMR-WB is still added as a media format. For example, in Jitsi Desktop, AMR-WB is still selectable but non-functional.

This change here re-enables AMR-WB but detects whether the used FFmpeg supports AMR-WB, at runtime. Consequently, when FFmpeg is missing or when the used FFmpeg does not support AMR-WB, it does not show up in Jitsi Desktop anymore. When FFmpeg is present and when AMR-WB is supported, AMR-WB is listed and functional. On Linux, this allows the user to add/remove just AMR-WB (or even the whole FFmpeg) within the system without re-compiling Jitsi Desktop.