### PR TITLE
H.263+: Remove non-working commented setting.

### DIFF
--- a/src/org/jitsi/impl/neomedia/codec/video/h263p/JNIEncoder.java
+++ b/src/org/jitsi/impl/neomedia/codec/video/h263p/JNIEncoder.java
@@ -235,8 +235,6 @@ public class JNIEncoder
         FFmpeg.avcodeccontext_set_mb_decision(avcontext,
             FFmpeg.FF_MB_DECISION_SIMPLE);
 
-        //FFmpeg.avcodeccontext_set_rc_eq(avcontext, "blurCplx^(1-qComp)");
-
         FFmpeg.avcodeccontext_add_flags(avcontext,
             FFmpeg.CODEC_FLAG_LOOP_FILTER);
         FFmpeg.avcodeccontext_add_flags(avcontext,


### PR DESCRIPTION
The source code contains a line of code which is about the rate-control equation (rc_eq). The given one does not work with the default H.263+ encoder in Debian/Ubuntu and gives the error messages `Unknown function` and `Error parsing`. Because that line of code is commented/disabled anyway, it is simply removed.