### PR TITLE
H.264: Set the motion-estimation method via private options.

### DIFF
--- a/src/org/jitsi/impl/neomedia/codec/video/h264/JNIEncoder.java
+++ b/src/org/jitsi/impl/neomedia/codec/video/h264/JNIEncoder.java
@@ -657,7 +657,6 @@ public class JNIEncoder
                     //"crf" /* constant quality mode, constant ratefactor */, "0",
                     "intra-refresh", intraRefresh ? "1" : "0",
                     "keyint", Integer.toString(keyint),
-                    "motion-est", "hex", /* possible since FFmpeg 2.7 */
                     "partitions", "b8x8,i4x4,p8x8",
                     "preset", preset,
                     "thread_type", "slice",

--- a/src/org/jitsi/impl/neomedia/codec/video/h264/JNIEncoder.java
+++ b/src/org/jitsi/impl/neomedia/codec/video/h264/JNIEncoder.java
@@ -614,7 +614,6 @@ public class JNIEncoder
             FFmpeg.avcodeccontext_add_flags2(avctx,
                 FFmpeg.CODEC_FLAG2_INTRA_REFRESH);
         }
-        FFmpeg.avcodeccontext_set_me_method(avctx, 7);
         FFmpeg.avcodeccontext_set_me_subpel_quality(avctx, 2);
         FFmpeg.avcodeccontext_set_me_range(avctx, 16);
         FFmpeg.avcodeccontext_set_me_cmp(avctx, FFmpeg.FF_CMP_CHROMA);
@@ -658,6 +657,7 @@ public class JNIEncoder
                     //"crf" /* constant quality mode, constant ratefactor */, "0",
                     "intra-refresh", intraRefresh ? "1" : "0",
                     "keyint", Integer.toString(keyint),
+                    "motion-est", "hex", /* possible since FFmpeg 2.7 */
                     "partitions", "b8x8,i4x4,p8x8",
                     "preset", preset,
                     "thread_type", "slice",


### PR DESCRIPTION
With FFmpeg 2.7, the motion-estimation method (me_method) was moved from a public symbol to the private options of the underlying encoder interface for libx264. Since FFmpeg 4.0, the public symbol me_method does not exist anymore. Because the latest supported is FFmpeg is 2.8, simply use the private-option interface instead.