### PR TITLE
H.263+: Remove non-working setting me_method.

### DIFF
--- a/src/org/jitsi/impl/neomedia/codec/video/h263p/JNIEncoder.java
+++ b/src/org/jitsi/impl/neomedia/codec/video/h263p/JNIEncoder.java
@@ -246,7 +246,6 @@ public class JNIEncoder
         FFmpeg.avcodeccontext_add_flags(avcontext,
                 FFmpeg.CODEC_FLAG_H263P_SLICE_STRUCT);
 
-        FFmpeg.avcodeccontext_set_me_method(avcontext, 6);
         FFmpeg.avcodeccontext_set_me_subpel_quality(avcontext, 2);
         FFmpeg.avcodeccontext_set_me_range(avcontext, 18);
         FFmpeg.avcodeccontext_set_me_cmp(avcontext, FFmpeg.FF_CMP_CHROMA);


### PR DESCRIPTION
The motion-estimation method (me_method) cannot be set for this encoder, at least not in the default encoder for Debian/Ubuntu. Furthermore, I am not aware of any H.263+ encoder which allows this. FFmpeg ignores unknown options silently. Because FFmpeg 4 moved that option to the private options and removed that public symbol completely, and because that option does not do anything in H.263+, it is simply removed.