### PR TITLE
H.264: Remove non-working setting rate-control equation.

### DIFF
--- a/src/org/jitsi/impl/neomedia/codec/video/h264/JNIEncoder.java
+++ b/src/org/jitsi/impl/neomedia/codec/video/h264/JNIEncoder.java
@@ -600,8 +600,6 @@ public class JNIEncoder
         FFmpeg.avcodeccontext_set_mb_decision(avctx,
             FFmpeg.FF_MB_DECISION_SIMPLE);
 
-        FFmpeg.avcodeccontext_set_rc_eq(avctx, "blurCplx^(1-qComp)");
-
         FFmpeg.avcodeccontext_add_flags(avctx,
                 FFmpeg.CODEC_FLAG_LOOP_FILTER);
         if (intraRefresh)


### PR DESCRIPTION
The rate-control equation (rc_eq) cannot be set for this encoder, at least not in the default encoder for Debian/Ubuntu. Furthermore, I am not aware of any H.264 encoder which allows this. FFmpeg ignores unknown options silently. Because FFmpeg 4 moved that option to the private options and removed that public symbol completely, and because that option does not do anything in H.264, it is simply removed.