### PR TITLE
FFmpeg: AVFilter: HFlip: Allow conversion between pixel formats.

### DIFF
--- a/src/org/jitsi/impl/neomedia/codec/video/HFlip.java
+++ b/src/org/jitsi/impl/neomedia/codec/video/HFlip.java
@@ -255,7 +255,7 @@ public class HFlip
                 String filters
                     = VSRC_BUFFER_NAME + "=" + size.width + ":" + size.height
                         + ":" + pixFmt + ":1:1000000:1:1,"
-                        + "hflip,"
+                        + "scale,hflip,scale,"
                         + "format=pix_fmts=" + pixFmt + ","
                         + VSINK_FFSINK_NAME;
                 long log_ctx = 0;
@@ -293,7 +293,7 @@ public class HFlip
                         parsedFilterName
                             = String.format(
                                     parsedFilterNameFormat,
-                                    3,
+                                    5,
                                     VSINK_FFSINK_NAME);
                         ffsink
                             = FFmpeg.avfilter_graph_get_filter(


### PR DESCRIPTION
This avoids the FFmpeg internal error message: The filters 'Parsed_buffer_0' and 'Parsed_hflip_1' do not have a common format and automatic conversion is disabled.

This happens, because the source (buffer) might use a pixel format which the filter (horizontal flip; hflip) is not able to use directly. Therefore, a conversion might be need which is enabled with the keyword scale. Because the sink (buffersink) shall have the same pixel format as the source, the same is required after the filter hflip.

closes jitsi/libjitsi#431
fixes jitsi/jitsi#540