### PR TITLE
MediaStream: Re-enable incoming video.

### DIFF
--- a/src/org/jitsi/impl/neomedia/MediaStreamImpl.java
+++ b/src/org/jitsi/impl/neomedia/MediaStreamImpl.java
@@ -611,7 +611,7 @@ public class MediaStreamImpl
             {
                 MediaDeviceSession deviceSession = getDeviceSession();
 
-                if (deviceSession == null || rtpTranslator != null)
+                if (deviceSession == null)
                 {
                     // Since there is no output MediaDevice to render the
                     // receiveStream on, the JitterBuffer of the receiveStream


### PR DESCRIPTION
caused by commit f60f781, undoing just the culprit

fixes jitsi/jitsi#627