### PR TITLE
Fixes receiving remove videos.

### DIFF
--- a/src/org/jitsi/impl/neomedia/MediaStreamImpl.java
+++ b/src/org/jitsi/impl/neomedia/MediaStreamImpl.java
@@ -611,7 +611,7 @@ public class MediaStreamImpl
             {
                 MediaDeviceSession deviceSession = getDeviceSession();
 
-                if (deviceSession == null || rtpTranslator != null)
+                if (deviceSession == null || deviceSession.useTranslator)
                 {
                     // Since there is no output MediaDevice to render the
                     // receiveStream on, the JitterBuffer of the receiveStream


### PR DESCRIPTION
The initial change was made in 912998b9, but was not taking in
consideration that all jitsi desktop video calls have a rtpTranslator,
and that change broke incoming video.
As this change is needed for jigasi, jigasi always sets useTranslator
for the audio and that setting is only used in that case.
fixes jitsi/jitsi#627
closes https://github.com/jitsi/libjitsi/pull/505

Thanks @traud for finding it.