### PR TITLE
Apache Felix (OSGi): Allow X11 to the Java Classloader.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
          <configuration>
             <excludeDependencies>jitsi-lgpl-dependencies</excludeDependencies>
             <instructions>
-               <Import-Package>*,sun.lwawt,sun.lwawt.macosx</Import-Package>
+               <Import-Package>*,sun.awt.X11,sun.lwawt,sun.lwawt.macosx</Import-Package>
                <Export-Package>org.jitsi.util.*,
                org.jitsi.service.*,
                org.jitsi.sctp4j.*,


### PR DESCRIPTION
Otherwise, sometimes (not reproducible), JAWT Rendering is not able to load the class sun.awt.x11.XErrorHandlerUtil.