### PR TITLE
AMR-WB: Enable VAD/DTX and use GSM compatible bitrate as default.

### DIFF
--- a/src/org/jitsi/impl/neomedia/codec/audio/amrwb/JNIEncoder.java
+++ b/src/org/jitsi/impl/neomedia/codec/audio/amrwb/JNIEncoder.java
@@ -101,7 +101,7 @@ public class JNIEncoder
     /**
      * The bit rate to be produced by this <tt>JNIEncoder</tt>.
      */
-    private int bitRate = BIT_RATES[BIT_RATES.length - 1];
+    private int bitRate = BIT_RATES[2]; // Mode 2 = 12650
 
     /**
      * The indicator which determines whether this <tt>JNIEncoder</tt> is to
@@ -131,6 +131,14 @@ public class JNIEncoder
         super.configureAVCodecContext(avctx, format);
 
         FFmpeg.avcodeccontext_set_bit_rate(avctx, bitRate);
+        /**
+         * Enable the voice-activation detection (VAD) included in the
+         * encoder which allows to transmit no RTP packets when no voice
+         * was detected. This is called discontinuous transmission (DTX)
+         * and reduces the used bandwidth.
+         */
+        long codec = 0; // if 0, avctx->codec is used
+        FFmpeg.avcodec_open2(avctx, codec, "dtx", "1"); // = on
     }
 
     /**
@@ -233,7 +241,7 @@ public class JNIEncoder
         return format;
     }
     
-        /**
+    /**
      * Gets the <tt>Format</tt> of the media output by this <tt>Codec</tt>.
      *
      * @return the <tt>Format</tt> of the media output by this <tt>Codec</tt>


### PR DESCRIPTION
AMR-WB is the bandwidth-efficient sibling of the HD audio codec G.722. Therefore, really leverage it features and enable voice-activation detection (VAD) so the RTP packets are transmitted discontinuously (DTX). Although this works with all versions of the encoder, at least version 0.1.5 of the OpenCORE-AMR decoder is recommended (comes in Debian 11 and Ubuntu 20.04 LTS), because previous versions had a bug in the Silence Descriptor (SID) decoding which resulted in white noise. Furthermore, to reduce the bandwidth even more, do not use the highest (AMR-WB Mode 8) but the GSM compatible bitrate as default (AMR-WB Mode 2). That still gives HD audio but works not only on UMTS (3G) but even on GSM links (2G).