### PR TITLE
Bouncy Castle 1.65 instead of 1.54

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
   <url>https://github.com/jitsi/libjitsi</url>
 
   <properties>
-    <bouncycastle.version>1.54</bouncycastle.version>
+    <bouncycastle.version>1.65</bouncycastle.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 


### PR DESCRIPTION
Bouncy Castle 1.65 instead of 1.54: https://www.bouncycastle.org/releasenotes.html
- http://www.bouncycastle.org/latest_releases.html

Note:
- In official source: https://polydistortion.net/bc/download/
Packages have not the "." in version.

- In maven.org:
Packages have "." in version.

CVEs: https://www.cvedetails.com/vulnerability-list/vendor_id-7637/Bouncycastle.html