### PR TITLE
fix: Skips injecting data in not started streams.

### DIFF
--- a/src/org/jitsi/impl/neomedia/MediaStreamImpl.java
+++ b/src/org/jitsi/impl/neomedia/MediaStreamImpl.java
@@ -3742,6 +3742,12 @@ public class MediaStreamImpl
     public void injectPacket(RawPacket pkt, boolean data, TransformEngine after, boolean create)
         throws TransmissionFailedException
     {
+        if (!isStarted())
+        {
+            // if stream is not started do not inject packet.
+            return;
+        }
+
         try
         {
             if (pkt == null || pkt.getBuffer() == null)


### PR DESCRIPTION
In case when we autocreate OutputDataStreams we can leak threads after the mediaStream is closed and we create new OutputDataStream.