### PR TITLE
fix: Initialize the zrtp timeout thred only when needed.

### DIFF
--- a/src/org/jitsi/impl/neomedia/MediaServiceImpl.java
+++ b/src/org/jitsi/impl/neomedia/MediaServiceImpl.java
@@ -35,6 +35,7 @@ import org.jitsi.impl.neomedia.device.*;
 import org.jitsi.impl.neomedia.format.*;
 import org.jitsi.impl.neomedia.recording.*;
 import org.jitsi.impl.neomedia.rtp.translator.*;
+import org.jitsi.impl.neomedia.transform.*;
 import org.jitsi.impl.neomedia.transform.dtls.*;
 import org.jitsi.impl.neomedia.transform.sdes.*;
 import org.jitsi.impl.neomedia.transform.zrtp.*;
@@ -766,6 +767,8 @@ public class MediaServiceImpl
             return new SDesControlImpl();
         case ZRTP:
             return new ZrtpControlImpl();
+        case NULL:
+            return new NullSrtpControl();
         default:
             return null;
         }

--- a/src/org/jitsi/impl/neomedia/MediaStreamImpl.java
+++ b/src/org/jitsi/impl/neomedia/MediaStreamImpl.java
@@ -407,14 +407,9 @@ public class MediaStreamImpl
             setDevice(device);
         }
 
-        // If you change the default behavior (initiates a ZrtpControlImpl if
-        // the srtpControl attribute is null), please accordingly modify the
-        // CallPeerMediaHandler.initStream function.
-        this.srtpControl
-                = (srtpControl == null)
-                    ? NeomediaServiceUtils.getMediaServiceImpl()
-                            .createSrtpControl(SrtpControlType.ZRTP)
-                    : srtpControl;
+        this.srtpControl = (srtpControl == null)
+            ? NeomediaServiceUtils.getMediaServiceImpl().createSrtpControl(SrtpControlType.NULL)
+            : srtpControl;
 
         this.srtpControl.registerUser(this);
         this.mediaStreamStatsImpl = new MediaStreamStats2Impl(this);

--- a/src/org/jitsi/impl/neomedia/transform/zrtp/ZRTPTransformEngine.java
+++ b/src/org/jitsi/impl/neomedia/transform/zrtp/ZRTPTransformEngine.java
@@ -577,6 +577,14 @@ public class ZRTPTransformEngine
         zrtpEngine
             = new ZRtp(zf.getZid(), this, clientIdString, config, mitmMode);
 
+        if (timeoutProvider == null)
+        {
+            timeoutProvider = new TimeoutProvider("ZRTP");
+            // XXX Daemon only if timeoutProvider is a global singleton.
+            // timeoutProvider.setDaemon(true);
+            timeoutProvider.start();
+        }
+
         enableZrtp = autoEnable;
         return true;
     }
@@ -622,15 +630,6 @@ public class ZRTPTransformEngine
     {
         if (zrtpEngine != null)
         {
-            // start the thread only when zrtp is used
-            if (timeoutProvider == null)
-            {
-                timeoutProvider = new TimeoutProvider("ZRTP");
-                // XXX Daemon only if timeoutProvider is a global singleton.
-                // timeoutProvider.setDaemon(true);
-                timeoutProvider.start();
-            }
-
             zrtpEngine.startZrtpEngine();
             started = true;
 

--- a/src/org/jitsi/impl/neomedia/transform/zrtp/ZRTPTransformEngine.java
+++ b/src/org/jitsi/impl/neomedia/transform/zrtp/ZRTPTransformEngine.java
@@ -577,14 +577,6 @@ public class ZRTPTransformEngine
         zrtpEngine
             = new ZRtp(zf.getZid(), this, clientIdString, config, mitmMode);
 
-        if (timeoutProvider == null)
-        {
-            timeoutProvider = new TimeoutProvider("ZRTP");
-            // XXX Daemon only if timeoutProvider is a global singleton.
-            // timeoutProvider.setDaemon(true);
-            timeoutProvider.start();
-        }
-
         enableZrtp = autoEnable;
         return true;
     }
@@ -630,6 +622,15 @@ public class ZRTPTransformEngine
     {
         if (zrtpEngine != null)
         {
+            // start the thread only when zrtp is used
+            if (timeoutProvider == null)
+            {
+                timeoutProvider = new TimeoutProvider("ZRTP");
+                // XXX Daemon only if timeoutProvider is a global singleton.
+                // timeoutProvider.setDaemon(true);
+                timeoutProvider.start();
+            }
+
             zrtpEngine.startZrtpEngine();
             started = true;
 


### PR DESCRIPTION
In jigasi we saw some TimeoutProvider threads leaking ... where zrtp is not used. Seems there is a scenario in which the ZRTPTransformEngine is initialized but never stopped/cleaned. And zrtp is not used there.
Rarely happening, but still happening 20 times out of 2k.