### PR TITLE
fix: Clears MediaStream stats when a receive stream is removed (by ssrc).

### DIFF
--- a/src/org/jitsi/impl/neomedia/MediaStreamImpl.java
+++ b/src/org/jitsi/impl/neomedia/MediaStreamImpl.java
@@ -2473,6 +2473,9 @@ public class MediaStreamImpl
 
         if (toRemove != null)
             removeReceiveStream(toRemove);
+
+        // handle removal of ssrc from stats
+        this.mediaStreamStatsImpl.removeReceiveSsrc(ssrc);
     }
 
     /**

--- a/src/org/jitsi/impl/neomedia/stats/MediaStreamStats2Impl.java
+++ b/src/org/jitsi/impl/neomedia/stats/MediaStreamStats2Impl.java
@@ -336,6 +336,15 @@ public class MediaStreamStats2Impl
     }
 
     /**
+     * Clears ssrc from receiver stats.
+     * @param ssrc the ssrc to process.
+     */
+    public void removeReceiveSsrc(long ssrc)
+    {
+        receiveSsrcStats.remove(ssrc);
+    }
+
+    /**
      * An {@link TrackStats} implementation which aggregates values for
      * a collection of {@link TrackStats} instances.
      */


### PR DESCRIPTION
…rc).