### PR TITLE
Incorrect interpretations of DTMF tones

### DIFF
--- a/src/main/java/org/jitsi/impl/neomedia/transform/dtmf/DtmfTransformEngine.java
+++ b/src/main/java/org/jitsi/impl/neomedia/transform/dtmf/DtmfTransformEngine.java
@@ -565,7 +565,6 @@ public class DtmfTransformEngine
                             lastReportedTone = null;
                         else
                             lastReportedTone = temp;
-                        toEnd = false;
                     }
                 }
             }


### PR DESCRIPTION
This change is created to fix incorrect interpretations of DTMF tones.

When I send a single digit DTMF tone with a duration, for example, 1000 [sendTones](https://github.com/jitsi/lib-jitsi-meet/blob/master/JitsiConference.js#L2528)

    sendTones(1, 1000)


this tone is caught by **[DtmfTransformEngine](https://github.com/jitsi/libjitsi/blob/master/src/main/java/org/jitsi/impl/neomedia/transform/dtmf/DtmfTransformEngine.java#L252)** as multiple **RawPacket**s

Every RawPacket is converted to DtmfRawPacket with isEnd boolean flag inside.

The amount of DtmfRawPackets depends on DTMF tone duration, for example
amount of 1000 - 5 packets with toEnd == false, and 3 packets with toEnd == true
amount of 2000 - 10 packets with toEnd == false, and 3 packets with toEnd == true

Then DtmfRawPackets go to synchronized block in **[addTonePacket](https://github.com/jitsi/libjitsi/blob/master/src/main/java/org/jitsi/impl/neomedia/transform/dtmf/DtmfTransformEngine.java#L580)**

**[Processing thread of DTMFDispatcher](https://github.com/jitsi/libjitsi/blob/master/src/main/java/org/jitsi/impl/neomedia/transform/dtmf/DtmfTransformEngine.java#L531)** gets current packet in synchronized block, let's say a packet1.
When it leaves synchronized block to process the packet1, another packet2 comes to **[addTonePacket](https://github.com/jitsi/libjitsi/blob/master/src/main/java/org/jitsi/impl/neomedia/transform/dtmf/DtmfTransformEngine.java#L580)** with for example toEnd = true
At the end of processing packet1 we set toEnd to false, but packet2 is not yet processed, so we will process it wrongly, with toEnd = false, instead of toEnd = true.

![2022-06-04 00-01-19](https://user-images.githubusercontent.com/1662963/171952163-6c8a7e06-198c-413c-9460-493be140c43e.png)

