### PR TITLE
Pin GitHub Actions to SHA hashes

### DIFF
--- a/.github/workflows/deploy-debian.yml
+++ b/.github/workflows/deploy-debian.yml
@@ -30,7 +30,7 @@ jobs:
     concurrency: ${{ github.event.inputs.release_type || inputs.release_type }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       # v1.12
       - uses: robinraju/release-downloader@daf26c55d821e836577a15f77d86ddc078948b05

--- a/.github/workflows/maven-and-native.yml
+++ b/.github/workflows/maven-and-native.yml
@@ -26,12 +26,12 @@ jobs:
       tag_name: ${{ steps.version.outputs.tag_name }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
 
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
         with:
           java-version: ${{ env.RELEASE_JAVA_VERSION }}
           distribution: temurin
@@ -39,7 +39,7 @@ jobs:
       # don't use the setup-java cache option as this only caches what is
       # necessary for the version, not the other jobs
       - name: Cache local Maven repository
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-version-${{ hashFiles('**/pom.xml') }}
@@ -83,12 +83,12 @@ jobs:
         java: [ 11, 17, 21 ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           submodules: false
 
       - name: Install Java ${{ matrix.java }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
         with:
           java-version: ${{ matrix.java }}
           distribution: temurin
@@ -99,7 +99,7 @@ jobs:
 
       - name: Upload JNI headers
         if: matrix.java == env.RELEASE_JAVA_VERSION
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: jni_headers
           path: target/native
@@ -118,13 +118,13 @@ jobs:
           - "ppc64el"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
           submodules: true
 
       - name: Get JNI headers
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           name: jni_headers
           path: target/native
@@ -142,7 +142,7 @@ jobs:
         run: ./resources/ubuntu-build-image/build-static.sh ${{ matrix.arch }} ${{ env.RELEASE_JAVA_VERSION }} "$(pwd)"
 
       - name: Upload Linux ${{ matrix.arch }} natives
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: linux-${{ matrix.arch }}
           path: src/main/resources/linux-*/*
@@ -177,13 +177,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
           submodules: true
 
       - name: Get JNI headers
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           name: jni_headers
           path: target/native
@@ -191,7 +191,7 @@ jobs:
       # don't use the setup-java cache option as this only caches what is
       # necessary for the version, not the other jobs
       - name: Cache local Maven repository
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-version-${{ hashFiles('**/pom.xml') }}
@@ -224,7 +224,7 @@ jobs:
             "dev+maven@jitsi.org"
 
       - name: Upload package as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: ${{ matrix.dist.vendor }}-${{ matrix.dist.dist }}-${{ matrix.arch }}
           path: target/debian/${{ matrix.dist.dist }}/*
@@ -241,20 +241,20 @@ jobs:
           - { actions: x64, cmake: x64, java: "x86-64" }
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
           submodules: true
 
       - name: Get JNI headers
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           name: jni_headers
           path: target/native
 
       - name: Install Java ${{ env.RELEASE_JAVA_VERSION }}
         id: install_java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
         with:
           distribution: temurin
           java-version: ${{ env.RELEASE_JAVA_VERSION }}
@@ -277,13 +277,13 @@ jobs:
 
       - name: Upload Debug logs
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: win32-debug-${{ matrix.arch.java }}
           path: target/debug*
 
       - name: Upload Windows ${{ matrix.arch.actions }} natives
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: win32-${{ matrix.arch.java }}
           path: src/main/resources/win32-*/*
@@ -300,20 +300,20 @@ jobs:
           - arm64
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
           submodules: true
 
       - name: Get JNI headers
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           name: jni_headers
           path: target/native
 
       - name: Install Java
         id: install_java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
         with:
           distribution: zulu
           java-version: ${{ env.RELEASE_JAVA_VERSION }}
@@ -332,13 +332,13 @@ jobs:
 
       - name: Upload Debug logs
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: darwin-debug-${{ matrix.arch }}
           path: target/debug*
 
       - name: Upload Mac natives
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: darwin-${{ matrix.arch }}
           path: src/main/resources/darwin-*/*
@@ -355,13 +355,13 @@ jobs:
       - deb
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
           submodules: false
 
       - name: Install Java ${{ env.RELEASE_JAVA_VERSION }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
         with:
           java-version: ${{ env.RELEASE_JAVA_VERSION }}
           distribution: temurin
@@ -371,7 +371,7 @@ jobs:
           server-password: SONATYPE_PW
 
       - name: Download binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           path: target
 
@@ -422,7 +422,7 @@ jobs:
             package
 
       - name: Upload Multi-Platform Jar
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: jar
           path: target/*.jar


### PR DESCRIPTION
Pin all GitHub Actions version tags to their corresponding commit SHA hashes for improved supply-chain security.

Original version tags are preserved as comments (e.g. `# v4`).