### PR TITLE
Skip deb package signing on PR builds

### DIFF
--- a/.github/workflows/maven-and-native.yml
+++ b/.github/workflows/maven-and-native.yml
@@ -201,7 +201,7 @@ jobs:
       - name: Install tools
         run: |
           # No need for updated man pages on GitHub
-          sudo rm /var/lib/man-db/auto-update
+          sudo rm -f /var/lib/man-db/auto-update
           resources/deb-prepare.sh
 
       - name: Import GPG key

--- a/.github/workflows/maven-and-native.yml
+++ b/.github/workflows/maven-and-native.yml
@@ -205,6 +205,7 @@ jobs:
           resources/deb-prepare.sh
 
       - name: Import GPG key
+        if: github.ref == 'refs/heads/master'
         env:
           GPG_PASSPHRASE: "${{ secrets.GPG_PW }}"
         run: |
@@ -221,7 +222,7 @@ jobs:
             "${{ needs.version.outputs.version }}" \
             "${{ matrix.dist.dist }}" \
             "${{ matrix.arch }}" \
-            "dev+maven@jitsi.org"
+            "${{ github.ref == 'refs/heads/master' && 'dev+maven@jitsi.org' || '' }}"
 
       - name: Upload package as artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4

--- a/resources/deb-build.sh
+++ b/resources/deb-build.sh
@@ -59,7 +59,9 @@ else
   sbuild --dist "${DIST}" --no-arch-all --arch="${ARCH}" "${PROJECT_DIR}"/../libjitsi_*.dsc
 fi
 
-debsign -S -e"${GPG_ID}" "${BUILD_DIR}"/*.changes --re-sign -p"${PROJECT_DIR}"/resources/gpg-wrap.sh
+if [[ -n "${GPG_ID}" ]]; then
+  debsign -S -e"${GPG_ID}" "${BUILD_DIR}"/*.changes --re-sign -p"${PROJECT_DIR}"/resources/gpg-wrap.sh
+fi
 
 #make build files readable for Windows and archivable for GitHub Actions
 rename 's|:|-|g' "$BUILD_DIR"/*.build


### PR DESCRIPTION
Secrets (GPG_KEY, GPG_PW) aren't available on PRs from forks, causing the GPG import step to fail with "no valid OpenPGP data found". Guard the import on master only and skip debsign when no GPG ID is provided so PRs still validate the deb build.